### PR TITLE
[FEAT] 쿠폰 API 구현 - 비관적 락, 낙관적 락

### DIFF
--- a/src/main/java/com/example/book_your_seat/coupon/CouponConst.java
+++ b/src/main/java/com/example/book_your_seat/coupon/CouponConst.java
@@ -1,0 +1,9 @@
+package com.example.book_your_seat.coupon;
+
+public final class CouponConst {
+    public static final String INVALID_COUPON_ID = "일치하는 쿠폰이 없습니다! Id: ";
+    public static final String DUPLICATE_BAD_REQUEST = "선착순 쿠폰은 중복 발급 받을 수 없습니다.";
+    public static final String COUPON_OUT_OF_STOCK = "쿠폰이 모두 소진되었습니다.";
+
+    private CouponConst() {}
+}

--- a/src/main/java/com/example/book_your_seat/coupon/CouponConst.java
+++ b/src/main/java/com/example/book_your_seat/coupon/CouponConst.java
@@ -1,6 +1,7 @@
 package com.example.book_your_seat.coupon;
 
 public final class CouponConst {
+    public static final String INVALID_COUPON_AMOUNT = "쿠폰 수량은 0개 이상이어야 합니다.";
     public static final String INVALID_COUPON_ID = "일치하는 쿠폰이 없습니다! Id: ";
     public static final String DUPLICATE_BAD_REQUEST = "선착순 쿠폰은 중복 발급 받을 수 없습니다.";
     public static final String COUPON_OUT_OF_STOCK = "쿠폰이 모두 소진되었습니다.";

--- a/src/main/java/com/example/book_your_seat/coupon/controller/CouponController.java
+++ b/src/main/java/com/example/book_your_seat/coupon/controller/CouponController.java
@@ -31,7 +31,8 @@ public class CouponController {
      */
     @PostMapping
     public ResponseEntity<CouponIdResponse> createCoupon(@RequestBody @Valid CouponCreateRequest couponCreateRequest) {
-        return ResponseEntity.status(HttpStatus.CREATED)
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
                 .body(couponCommandService.createCoupon(couponCreateRequest));
     }
 

--- a/src/main/java/com/example/book_your_seat/coupon/controller/CouponController.java
+++ b/src/main/java/com/example/book_your_seat/coupon/controller/CouponController.java
@@ -1,28 +1,12 @@
 package com.example.book_your_seat.coupon.controller;
 
-import com.example.book_your_seat.coupon.dto.UserCouponResponse;
-import com.example.book_your_seat.coupon.service.CouponCommandService;
-import com.example.book_your_seat.user.domain.User;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
-
-import static com.example.book_your_seat.common.SessionConst.LOGIN_USER;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/coupons")
 @RestController
 public class CouponController {
 
-    private final CouponCommandService couponCommandService;
-
-    @PostMapping()
-    public ResponseEntity<UserCouponResponse> issueCouponWithPessimistic(
-            @SessionAttribute(LOGIN_USER) User user, @RequestParam("couponId") Long couponId
-    ) {
-        return ResponseEntity
-                .status(HttpStatus.CREATED)
-                .body(couponCommandService.issueCouponWithPessimistic(user, couponId));
-    }
 }

--- a/src/main/java/com/example/book_your_seat/coupon/controller/CouponController.java
+++ b/src/main/java/com/example/book_your_seat/coupon/controller/CouponController.java
@@ -1,0 +1,28 @@
+package com.example.book_your_seat.coupon.controller;
+
+import com.example.book_your_seat.coupon.dto.UserCouponResponse;
+import com.example.book_your_seat.coupon.service.CouponCommandService;
+import com.example.book_your_seat.user.domain.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import static com.example.book_your_seat.common.SessionConst.LOGIN_USER;
+
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/coupons")
+@RestController
+public class CouponController {
+
+    private final CouponCommandService couponCommandService;
+
+    @PostMapping()
+    public ResponseEntity<UserCouponResponse> issueCouponWithPessimistic(
+            @SessionAttribute(LOGIN_USER) User user, @RequestParam("couponId") Long couponId
+    ) {
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(couponCommandService.issueCouponWithPessimistic(user, couponId));
+    }
+}

--- a/src/main/java/com/example/book_your_seat/coupon/controller/CouponController.java
+++ b/src/main/java/com/example/book_your_seat/coupon/controller/CouponController.java
@@ -31,7 +31,8 @@ public class CouponController {
      */
     @PostMapping
     public ResponseEntity<CouponIdResponse> createCoupon(@RequestBody @Valid CouponCreateRequest couponCreateRequest) {
-        return ResponseEntity.status(HttpStatus.CREATED).body(couponCommandService.createCoupon(couponCreateRequest));
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(couponCommandService.createCoupon(couponCreateRequest));
     }
 
     /**
@@ -41,7 +42,8 @@ public class CouponController {
      */
     @GetMapping("/my")
     public ResponseEntity<List<UserCouponResponse>> getUserCoupons(@SessionAttribute(LOGIN_USER) User user) {
-        return ResponseEntity.ok().body(couponQueryService.getUserCoupons(user));
+        return ResponseEntity.ok()
+                .body(couponQueryService.getUserCoupons(user));
     }
 
 }

--- a/src/main/java/com/example/book_your_seat/coupon/controller/CouponController.java
+++ b/src/main/java/com/example/book_your_seat/coupon/controller/CouponController.java
@@ -1,12 +1,28 @@
 package com.example.book_your_seat.coupon.controller;
 
+import com.example.book_your_seat.coupon.controller.dto.CouponCreateRequest;
+import com.example.book_your_seat.coupon.controller.dto.CouponIdResponse;
+import com.example.book_your_seat.coupon.service.CouponCommandService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
 
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/coupons")
 @RestController
 public class CouponController {
 
+    private final CouponCommandService couponCommandService;
+
+    /**
+     * 쿠폰 생성 (추후 관리자 권한 추가)
+     * @param couponCreateRequest{amount, discountRate}
+     * @return couponResponse{couponId}
+     */
+    @PostMapping
+    public ResponseEntity<CouponIdResponse> createCoupon(@RequestBody @Valid CouponCreateRequest couponCreateRequest) {
+        return ResponseEntity.status(HttpStatus.CREATED).body(couponCommandService.createCoupon(couponCreateRequest));
+    }
 }

--- a/src/main/java/com/example/book_your_seat/coupon/controller/CouponController.java
+++ b/src/main/java/com/example/book_your_seat/coupon/controller/CouponController.java
@@ -2,12 +2,19 @@ package com.example.book_your_seat.coupon.controller;
 
 import com.example.book_your_seat.coupon.controller.dto.CouponCreateRequest;
 import com.example.book_your_seat.coupon.controller.dto.CouponIdResponse;
+import com.example.book_your_seat.coupon.controller.dto.UserCouponResponse;
 import com.example.book_your_seat.coupon.service.CouponCommandService;
+import com.example.book_your_seat.coupon.service.CouponQueryService;
+import com.example.book_your_seat.user.domain.User;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+import static com.example.book_your_seat.common.SessionConst.LOGIN_USER;
 
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/coupons")
@@ -15,6 +22,7 @@ import org.springframework.web.bind.annotation.*;
 public class CouponController {
 
     private final CouponCommandService couponCommandService;
+    private final CouponQueryService couponQueryService;
 
     /**
      * 쿠폰 생성 (추후 관리자 권한 추가)
@@ -25,4 +33,15 @@ public class CouponController {
     public ResponseEntity<CouponIdResponse> createCoupon(@RequestBody @Valid CouponCreateRequest couponCreateRequest) {
         return ResponseEntity.status(HttpStatus.CREATED).body(couponCommandService.createCoupon(couponCreateRequest));
     }
+
+    /**
+     * 내 쿠폰 목록 조회
+     * @param user
+     * @return List<UserCouponResponse{userCouponId, discountRate, expirationDate, isUsed}>
+     */
+    @GetMapping("/my")
+    public ResponseEntity<List<UserCouponResponse>> getUserCoupons(@SessionAttribute(LOGIN_USER) User user) {
+        return ResponseEntity.ok().body(couponQueryService.getUserCoupons(user));
+    }
+
 }

--- a/src/main/java/com/example/book_your_seat/coupon/controller/dto/CouponCreateRequest.java
+++ b/src/main/java/com/example/book_your_seat/coupon/controller/dto/CouponCreateRequest.java
@@ -1,0 +1,16 @@
+package com.example.book_your_seat.coupon.controller.dto;
+
+import com.example.book_your_seat.coupon.domain.DiscountRate;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+
+import static com.example.book_your_seat.coupon.CouponConst.INVALID_COUPON_AMOUNT;
+
+public record CouponCreateRequest(
+        @NotNull
+        @Min(value = 0, message = INVALID_COUPON_AMOUNT)
+        int amount,
+        @NotNull
+        DiscountRate discountRate
+) {
+}

--- a/src/main/java/com/example/book_your_seat/coupon/controller/dto/CouponCreateRequest.java
+++ b/src/main/java/com/example/book_your_seat/coupon/controller/dto/CouponCreateRequest.java
@@ -1,8 +1,11 @@
 package com.example.book_your_seat.coupon.controller.dto;
 
 import com.example.book_your_seat.coupon.domain.DiscountRate;
+import jakarta.validation.constraints.Future;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
+
+import java.time.LocalDate;
 
 import static com.example.book_your_seat.coupon.CouponConst.INVALID_COUPON_AMOUNT;
 
@@ -10,7 +13,12 @@ public record CouponCreateRequest(
         @NotNull
         @Min(value = 0, message = INVALID_COUPON_AMOUNT)
         int amount,
+
         @NotNull
-        DiscountRate discountRate
+        DiscountRate discountRate,
+
+        @NotNull
+        @Future
+        LocalDate expirationDate
 ) {
 }

--- a/src/main/java/com/example/book_your_seat/coupon/controller/dto/CouponIdResponse.java
+++ b/src/main/java/com/example/book_your_seat/coupon/controller/dto/CouponIdResponse.java
@@ -1,0 +1,6 @@
+package com.example.book_your_seat.coupon.controller.dto;
+
+public record CouponIdResponse (
+        Long couponId
+) {
+}

--- a/src/main/java/com/example/book_your_seat/coupon/controller/dto/UserCouponIdResponse.java
+++ b/src/main/java/com/example/book_your_seat/coupon/controller/dto/UserCouponIdResponse.java
@@ -1,0 +1,6 @@
+package com.example.book_your_seat.coupon.controller.dto;
+
+public record UserCouponIdResponse(
+        Long userCouponId
+) {
+}

--- a/src/main/java/com/example/book_your_seat/coupon/controller/dto/UserCouponResponse.java
+++ b/src/main/java/com/example/book_your_seat/coupon/controller/dto/UserCouponResponse.java
@@ -1,4 +1,4 @@
-package com.example.book_your_seat.coupon.dto;
+package com.example.book_your_seat.coupon.controller.dto;
 
 public record UserCouponResponse(
         Long userCouponId

--- a/src/main/java/com/example/book_your_seat/coupon/controller/dto/UserCouponResponse.java
+++ b/src/main/java/com/example/book_your_seat/coupon/controller/dto/UserCouponResponse.java
@@ -1,6 +1,13 @@
 package com.example.book_your_seat.coupon.controller.dto;
 
+import com.example.book_your_seat.coupon.domain.DiscountRate;
+
+import java.time.LocalDate;
+
 public record UserCouponResponse(
-        Long userCouponId
+        Long userCouponId,
+        DiscountRate discountRate,
+        LocalDate expirationDate,
+        Boolean isUsed
 ) {
 }

--- a/src/main/java/com/example/book_your_seat/coupon/domain/Coupon.java
+++ b/src/main/java/com/example/book_your_seat/coupon/domain/Coupon.java
@@ -1,15 +1,7 @@
 package com.example.book_your_seat.coupon.domain;
 
 import com.example.book_your_seat.common.entity.BaseEntity;
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.OneToMany;
+import jakarta.persistence.*;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -34,6 +26,10 @@ public class Coupon extends BaseEntity {
 
     @OneToMany(mappedBy = "coupon", cascade = CascadeType.ALL)
     private final List<UserCoupon> userCoupons = new ArrayList<>();
+
+    //낙관적 락을 위한 버전
+    @Version
+    private Long version;
 
     public Coupon(int amount, DiscountRate discountRate) {
         this.amount = amount;

--- a/src/main/java/com/example/book_your_seat/coupon/domain/Coupon.java
+++ b/src/main/java/com/example/book_your_seat/coupon/domain/Coupon.java
@@ -39,6 +39,10 @@ public class Coupon extends BaseEntity {
         this.expirationDate = expirationDate;
     }
 
+    public boolean noAmount() {
+        return this.amount <= 0;
+    }
+
     public void addUserCoupon(UserCoupon userCoupon) {
         this.userCoupons.add(userCoupon);
     }

--- a/src/main/java/com/example/book_your_seat/coupon/domain/Coupon.java
+++ b/src/main/java/com/example/book_your_seat/coupon/domain/Coupon.java
@@ -2,14 +2,13 @@ package com.example.book_your_seat.coupon.domain;
 
 import com.example.book_your_seat.common.entity.BaseEntity;
 import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
-
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
@@ -34,9 +33,10 @@ public class Coupon extends BaseEntity {
     @Version
     private Long version;
 
-    public Coupon(int amount, DiscountRate discountRate) {
+    public Coupon(int amount, DiscountRate discountRate, LocalDate expirationDate) {
         this.amount = amount;
         this.discountRate = discountRate;
+        this.expirationDate = expirationDate;
     }
 
     public void addUserCoupon(UserCoupon userCoupon) {

--- a/src/main/java/com/example/book_your_seat/coupon/domain/Coupon.java
+++ b/src/main/java/com/example/book_your_seat/coupon/domain/Coupon.java
@@ -10,8 +10,10 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
+
 import java.util.ArrayList;
 import java.util.List;
+
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -40,5 +42,9 @@ public class Coupon extends BaseEntity {
 
     public void addUserCoupon(UserCoupon userCoupon) {
         this.userCoupons.add(userCoupon);
+    }
+
+    public void decreaseAmount() {
+        this.amount -= 1;
     }
 }

--- a/src/main/java/com/example/book_your_seat/coupon/domain/Coupon.java
+++ b/src/main/java/com/example/book_your_seat/coupon/domain/Coupon.java
@@ -3,6 +3,7 @@ package com.example.book_your_seat.coupon.domain;
 import com.example.book_your_seat.common.entity.BaseEntity;
 import jakarta.persistence.*;
 
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -23,6 +24,8 @@ public class Coupon extends BaseEntity {
 
     @Enumerated(EnumType.STRING)
     private DiscountRate discountRate;
+
+    private LocalDate expirationDate;
 
     @OneToMany(mappedBy = "coupon", cascade = CascadeType.ALL)
     private final List<UserCoupon> userCoupons = new ArrayList<>();

--- a/src/main/java/com/example/book_your_seat/coupon/domain/UserCoupon.java
+++ b/src/main/java/com/example/book_your_seat/coupon/domain/UserCoupon.java
@@ -31,6 +31,8 @@ public class UserCoupon extends BaseEntity {
     @JoinColumn(name = "coupon_id")
     private Coupon coupon;
 
+    private boolean isUsed;
+
     public UserCoupon(User user, Coupon coupon) {
         this.user = user;
         this.coupon = coupon;

--- a/src/main/java/com/example/book_your_seat/coupon/domain/UserCoupon.java
+++ b/src/main/java/com/example/book_your_seat/coupon/domain/UserCoupon.java
@@ -36,6 +36,7 @@ public class UserCoupon extends BaseEntity {
     public UserCoupon(User user, Coupon coupon) {
         this.user = user;
         this.coupon = coupon;
+        this.isUsed = false;
         user.adduserCoupon(this);
         coupon.addUserCoupon(this);
     }

--- a/src/main/java/com/example/book_your_seat/coupon/dto/UserCouponResponse.java
+++ b/src/main/java/com/example/book_your_seat/coupon/dto/UserCouponResponse.java
@@ -1,0 +1,6 @@
+package com.example.book_your_seat.coupon.dto;
+
+public record UserCouponResponse(
+        Long userCouponId
+) {
+}

--- a/src/main/java/com/example/book_your_seat/coupon/facade/OptimisticLockCouponFacade.java
+++ b/src/main/java/com/example/book_your_seat/coupon/facade/OptimisticLockCouponFacade.java
@@ -1,0 +1,25 @@
+package com.example.book_your_seat.coupon.facade;
+
+import com.example.book_your_seat.coupon.service.CouponCommandService;
+import com.example.book_your_seat.user.domain.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class OptimisticLockCouponFacade {
+
+    private final CouponCommandService couponCommandService;
+
+    public void issueCouponWithOptimistic(User user, Long couponId) throws InterruptedException {
+        while(true) {
+            try {
+                couponCommandService.issueCouponWithOptimistic(user, couponId);
+                break;
+            } catch (ObjectOptimisticLockingFailureException e) {
+                Thread.sleep(50);
+            }
+        }
+    }
+}

--- a/src/main/java/com/example/book_your_seat/coupon/repository/CouponRepository.java
+++ b/src/main/java/com/example/book_your_seat/coupon/repository/CouponRepository.java
@@ -1,7 +1,16 @@
 package com.example.book_your_seat.coupon.repository;
 
 import com.example.book_your_seat.coupon.domain.Coupon;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.Optional;
 
 public interface CouponRepository extends JpaRepository<Coupon, Long> {
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT c FROM Coupon c WHERE c.id = :couponId")
+    Optional<Coupon> findByIdWithPessimistic(Long couponId);
 }

--- a/src/main/java/com/example/book_your_seat/coupon/repository/CouponRepository.java
+++ b/src/main/java/com/example/book_your_seat/coupon/repository/CouponRepository.java
@@ -13,4 +13,8 @@ public interface CouponRepository extends JpaRepository<Coupon, Long> {
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("SELECT c FROM Coupon c WHERE c.id = :couponId")
     Optional<Coupon> findByIdWithPessimistic(Long couponId);
+
+    @Lock(LockModeType.OPTIMISTIC)
+    @Query("SELECT c FROM Coupon c WHERE c.id = :couponId")
+    Optional<Coupon> findByIdWithOptimistic(Long couponId);
 }

--- a/src/main/java/com/example/book_your_seat/coupon/repository/UserCouponRepository.java
+++ b/src/main/java/com/example/book_your_seat/coupon/repository/UserCouponRepository.java
@@ -1,7 +1,13 @@
 package com.example.book_your_seat.coupon.repository;
 
 import com.example.book_your_seat.coupon.domain.UserCoupon;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+
+import java.util.Optional;
 
 public interface UserCouponRepository extends JpaRepository<UserCoupon, Long> {
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    Optional<UserCoupon> findByUserIdAndCouponId(Long userId, Long couponId);
 }

--- a/src/main/java/com/example/book_your_seat/coupon/repository/UserCouponRepository.java
+++ b/src/main/java/com/example/book_your_seat/coupon/repository/UserCouponRepository.java
@@ -1,13 +1,19 @@
 package com.example.book_your_seat.coupon.repository;
 
 import com.example.book_your_seat.coupon.domain.UserCoupon;
+import com.example.book_your_seat.user.domain.User;
 import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface UserCouponRepository extends JpaRepository<UserCoupon, Long> {
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     Optional<UserCoupon> findByUserIdAndCouponId(Long userId, Long couponId);
+
+    @Query("SELECT uc FROM UserCoupon uc JOIN FETCH uc.coupon WHERE uc.user = :user")
+    List<UserCoupon> findAllByUser(User user);
 }

--- a/src/main/java/com/example/book_your_seat/coupon/service/CouponCommandService.java
+++ b/src/main/java/com/example/book_your_seat/coupon/service/CouponCommandService.java
@@ -2,12 +2,12 @@ package com.example.book_your_seat.coupon.service;
 
 import com.example.book_your_seat.coupon.controller.dto.CouponCreateRequest;
 import com.example.book_your_seat.coupon.controller.dto.CouponIdResponse;
-import com.example.book_your_seat.coupon.controller.dto.UserCouponResponse;
+import com.example.book_your_seat.coupon.controller.dto.UserCouponIdResponse;
 import com.example.book_your_seat.user.domain.User;
 
 public interface CouponCommandService {
-    UserCouponResponse issueCouponWithPessimistic(User user, Long couponId);
-    UserCouponResponse issueCouponWithOptimistic(User user, Long couponId);
+    UserCouponIdResponse issueCouponWithPessimistic(User user, Long couponId);
+    UserCouponIdResponse issueCouponWithOptimistic(User user, Long couponId);
     CouponIdResponse createCoupon(CouponCreateRequest couponCreateRequest);
 
 }

--- a/src/main/java/com/example/book_your_seat/coupon/service/CouponCommandService.java
+++ b/src/main/java/com/example/book_your_seat/coupon/service/CouponCommandService.java
@@ -5,4 +5,6 @@ import com.example.book_your_seat.user.domain.User;
 
 public interface CouponCommandService {
     UserCouponResponse issueCouponWithPessimistic(User user, Long couponId);
+    UserCouponResponse issueCouponWithOptimistic(User user, Long couponId);
+
 }

--- a/src/main/java/com/example/book_your_seat/coupon/service/CouponCommandService.java
+++ b/src/main/java/com/example/book_your_seat/coupon/service/CouponCommandService.java
@@ -1,0 +1,8 @@
+package com.example.book_your_seat.coupon.service;
+
+import com.example.book_your_seat.coupon.dto.UserCouponResponse;
+import com.example.book_your_seat.user.domain.User;
+
+public interface CouponCommandService {
+    UserCouponResponse issueCouponWithPessimistic(User user, Long couponId);
+}

--- a/src/main/java/com/example/book_your_seat/coupon/service/CouponCommandService.java
+++ b/src/main/java/com/example/book_your_seat/coupon/service/CouponCommandService.java
@@ -1,10 +1,13 @@
 package com.example.book_your_seat.coupon.service;
 
-import com.example.book_your_seat.coupon.dto.UserCouponResponse;
+import com.example.book_your_seat.coupon.controller.dto.CouponCreateRequest;
+import com.example.book_your_seat.coupon.controller.dto.CouponIdResponse;
+import com.example.book_your_seat.coupon.controller.dto.UserCouponResponse;
 import com.example.book_your_seat.user.domain.User;
 
 public interface CouponCommandService {
     UserCouponResponse issueCouponWithPessimistic(User user, Long couponId);
     UserCouponResponse issueCouponWithOptimistic(User user, Long couponId);
+    CouponIdResponse createCoupon(CouponCreateRequest couponCreateRequest);
 
 }

--- a/src/main/java/com/example/book_your_seat/coupon/service/CouponCommandServiceImpl.java
+++ b/src/main/java/com/example/book_your_seat/coupon/service/CouponCommandServiceImpl.java
@@ -36,7 +36,7 @@ public class CouponCommandServiceImpl implements CouponCommandService {
         checkDuplicate(user.getId(), couponId);
 
         //수량 체크
-        if(coupon.getAmount() <= 0) {
+        if(coupon.noAmount()) {
             throw new IllegalArgumentException(COUPON_OUT_OF_STOCK);
         }
 
@@ -59,7 +59,7 @@ public class CouponCommandServiceImpl implements CouponCommandService {
         checkDuplicate(user.getId(), couponId);
 
         //수량 체크
-        if(coupon.getAmount() <= 0) {
+        if(coupon.noAmount()) {
             throw new IllegalArgumentException(COUPON_OUT_OF_STOCK);
         }
 

--- a/src/main/java/com/example/book_your_seat/coupon/service/CouponCommandServiceImpl.java
+++ b/src/main/java/com/example/book_your_seat/coupon/service/CouponCommandServiceImpl.java
@@ -1,0 +1,49 @@
+package com.example.book_your_seat.coupon.service;
+
+import com.example.book_your_seat.coupon.domain.Coupon;
+import com.example.book_your_seat.coupon.domain.UserCoupon;
+import com.example.book_your_seat.coupon.dto.UserCouponResponse;
+import com.example.book_your_seat.coupon.repository.UserCouponRepository;
+import com.example.book_your_seat.user.domain.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import static com.example.book_your_seat.coupon.CouponConst.COUPON_OUT_OF_STOCK;
+import static com.example.book_your_seat.coupon.CouponConst.DUPLICATE_BAD_REQUEST;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class CouponCommandServiceImpl implements CouponCommandService {
+
+    private final UserCouponRepository userCouponRepository;
+    private final CouponQueryService couponQueryService;
+
+    //비관적 락
+    public UserCouponResponse issueCouponWithPessimistic(User user, Long couponId) {
+
+        Coupon coupon = couponQueryService.findByIdWithPessimistic(couponId);
+
+        //선착순 쿠폰 중복수령 방지
+        checkDuplicate(user.getId(), couponId);
+
+        //수량 체크
+        if(coupon.getAmount() > 0) {
+            coupon.decreaseAmount();
+        } else {
+            throw new IllegalArgumentException(COUPON_OUT_OF_STOCK);
+        }
+
+        return new UserCouponResponse(
+                userCouponRepository.save(new UserCoupon(user, coupon)).getId()
+        );
+    }
+
+    private void checkDuplicate(Long userId, Long couponId) {
+        userCouponRepository.findByUserIdAndCouponId(userId, couponId).ifPresent(userCoupon -> {
+                    throw new IllegalArgumentException(DUPLICATE_BAD_REQUEST);
+                }
+        );
+    }
+}

--- a/src/main/java/com/example/book_your_seat/coupon/service/CouponCommandServiceImpl.java
+++ b/src/main/java/com/example/book_your_seat/coupon/service/CouponCommandServiceImpl.java
@@ -4,7 +4,7 @@ import com.example.book_your_seat.coupon.controller.dto.CouponCreateRequest;
 import com.example.book_your_seat.coupon.controller.dto.CouponIdResponse;
 import com.example.book_your_seat.coupon.domain.Coupon;
 import com.example.book_your_seat.coupon.domain.UserCoupon;
-import com.example.book_your_seat.coupon.controller.dto.UserCouponResponse;
+import com.example.book_your_seat.coupon.controller.dto.UserCouponIdResponse;
 import com.example.book_your_seat.coupon.repository.CouponRepository;
 import com.example.book_your_seat.coupon.repository.UserCouponRepository;
 import com.example.book_your_seat.user.domain.User;
@@ -28,7 +28,7 @@ public class CouponCommandServiceImpl implements CouponCommandService {
     쿠폰 발급 - 비관적 락
      */
     @Override
-    public UserCouponResponse issueCouponWithPessimistic(User user, Long couponId) {
+    public UserCouponIdResponse issueCouponWithPessimistic(User user, Long couponId) {
 
         Coupon coupon = couponQueryService.findByIdWithPessimistic(couponId);
 
@@ -42,7 +42,7 @@ public class CouponCommandServiceImpl implements CouponCommandService {
 
         coupon.decreaseAmount();
 
-        return new UserCouponResponse(
+        return new UserCouponIdResponse(
                 userCouponRepository.save(new UserCoupon(user, coupon)).getId()
         );
     }
@@ -51,7 +51,7 @@ public class CouponCommandServiceImpl implements CouponCommandService {
     쿠폰 발급 - 낙관적 락
     */
     @Override
-    public UserCouponResponse issueCouponWithOptimistic(User user, Long couponId) {
+    public UserCouponIdResponse issueCouponWithOptimistic(User user, Long couponId) {
 
         Coupon coupon = couponQueryService.findByIdWithOptimistic(couponId);
 
@@ -65,7 +65,7 @@ public class CouponCommandServiceImpl implements CouponCommandService {
 
         coupon.decreaseAmount();
 
-        return new UserCouponResponse(
+        return new UserCouponIdResponse(
                 userCouponRepository.save(new UserCoupon(user, coupon)).getId()
         );
 
@@ -77,7 +77,7 @@ public class CouponCommandServiceImpl implements CouponCommandService {
     @Override
     public CouponIdResponse createCoupon(CouponCreateRequest request) {
         return new CouponIdResponse(
-                couponRepository.save(new Coupon(request.amount(), request.discountRate())).getId()
+                couponRepository.save(new Coupon(request.amount(), request.discountRate(),request.expirationDate())).getId()
         );
     }
 

--- a/src/main/java/com/example/book_your_seat/coupon/service/CouponCommandServiceImpl.java
+++ b/src/main/java/com/example/book_your_seat/coupon/service/CouponCommandServiceImpl.java
@@ -1,8 +1,11 @@
 package com.example.book_your_seat.coupon.service;
 
+import com.example.book_your_seat.coupon.controller.dto.CouponCreateRequest;
+import com.example.book_your_seat.coupon.controller.dto.CouponIdResponse;
 import com.example.book_your_seat.coupon.domain.Coupon;
 import com.example.book_your_seat.coupon.domain.UserCoupon;
-import com.example.book_your_seat.coupon.dto.UserCouponResponse;
+import com.example.book_your_seat.coupon.controller.dto.UserCouponResponse;
+import com.example.book_your_seat.coupon.repository.CouponRepository;
 import com.example.book_your_seat.coupon.repository.UserCouponRepository;
 import com.example.book_your_seat.user.domain.User;
 import lombok.RequiredArgsConstructor;
@@ -17,10 +20,14 @@ import static com.example.book_your_seat.coupon.CouponConst.DUPLICATE_BAD_REQUES
 @RequiredArgsConstructor
 public class CouponCommandServiceImpl implements CouponCommandService {
 
+    private final CouponRepository couponRepository;
     private final UserCouponRepository userCouponRepository;
     private final CouponQueryService couponQueryService;
 
-    //비관적 락
+    /*
+    쿠폰 발급 - 비관적 락
+     */
+    @Override
     public UserCouponResponse issueCouponWithPessimistic(User user, Long couponId) {
 
         Coupon coupon = couponQueryService.findByIdWithPessimistic(couponId);
@@ -40,7 +47,10 @@ public class CouponCommandServiceImpl implements CouponCommandService {
         );
     }
 
-    //낙관적 락
+    /*
+    쿠폰 발급 - 낙관적 락
+    */
+    @Override
     public UserCouponResponse issueCouponWithOptimistic(User user, Long couponId) {
 
         Coupon coupon = couponQueryService.findByIdWithOptimistic(couponId);
@@ -59,6 +69,16 @@ public class CouponCommandServiceImpl implements CouponCommandService {
                 userCouponRepository.save(new UserCoupon(user, coupon)).getId()
         );
 
+    }
+
+    /*
+    쿠폰 생성
+     */
+    @Override
+    public CouponIdResponse createCoupon(CouponCreateRequest request) {
+        return new CouponIdResponse(
+                couponRepository.save(new Coupon(request.amount(), request.discountRate())).getId()
+        );
     }
 
     private void checkDuplicate(Long userId, Long couponId) {

--- a/src/main/java/com/example/book_your_seat/coupon/service/CouponCommandServiceImpl.java
+++ b/src/main/java/com/example/book_your_seat/coupon/service/CouponCommandServiceImpl.java
@@ -29,15 +29,36 @@ public class CouponCommandServiceImpl implements CouponCommandService {
         checkDuplicate(user.getId(), couponId);
 
         //수량 체크
-        if(coupon.getAmount() > 0) {
-            coupon.decreaseAmount();
-        } else {
+        if(coupon.getAmount() <= 0) {
             throw new IllegalArgumentException(COUPON_OUT_OF_STOCK);
         }
+
+        coupon.decreaseAmount();
 
         return new UserCouponResponse(
                 userCouponRepository.save(new UserCoupon(user, coupon)).getId()
         );
+    }
+
+    //낙관적 락
+    public UserCouponResponse issueCouponWithOptimistic(User user, Long couponId) {
+
+        Coupon coupon = couponQueryService.findByIdWithOptimistic(couponId);
+
+        //선착순 쿠폰 중복수령 방지
+        checkDuplicate(user.getId(), couponId);
+
+        //수량 체크
+        if(coupon.getAmount() <= 0) {
+            throw new IllegalArgumentException(COUPON_OUT_OF_STOCK);
+        }
+
+        coupon.decreaseAmount();
+
+        return new UserCouponResponse(
+                userCouponRepository.save(new UserCoupon(user, coupon)).getId()
+        );
+
     }
 
     private void checkDuplicate(Long userId, Long couponId) {

--- a/src/main/java/com/example/book_your_seat/coupon/service/CouponQueryService.java
+++ b/src/main/java/com/example/book_your_seat/coupon/service/CouponQueryService.java
@@ -1,8 +1,13 @@
 package com.example.book_your_seat.coupon.service;
 
+import com.example.book_your_seat.coupon.controller.dto.UserCouponResponse;
 import com.example.book_your_seat.coupon.domain.Coupon;
+import com.example.book_your_seat.user.domain.User;
+
+import java.util.List;
 
 public interface CouponQueryService {
     Coupon findByIdWithPessimistic(Long couponId);
     Coupon findByIdWithOptimistic(Long couponId);
+    List<UserCouponResponse> getUserCoupons(User user);
 }

--- a/src/main/java/com/example/book_your_seat/coupon/service/CouponQueryService.java
+++ b/src/main/java/com/example/book_your_seat/coupon/service/CouponQueryService.java
@@ -1,0 +1,7 @@
+package com.example.book_your_seat.coupon.service;
+
+import com.example.book_your_seat.coupon.domain.Coupon;
+
+public interface CouponQueryService {
+    Coupon findByIdWithPessimistic(Long couponId);
+}

--- a/src/main/java/com/example/book_your_seat/coupon/service/CouponQueryService.java
+++ b/src/main/java/com/example/book_your_seat/coupon/service/CouponQueryService.java
@@ -4,4 +4,5 @@ import com.example.book_your_seat.coupon.domain.Coupon;
 
 public interface CouponQueryService {
     Coupon findByIdWithPessimistic(Long couponId);
+    Coupon findByIdWithOptimistic(Long couponId);
 }

--- a/src/main/java/com/example/book_your_seat/coupon/service/CouponQueryServiceImpl.java
+++ b/src/main/java/com/example/book_your_seat/coupon/service/CouponQueryServiceImpl.java
@@ -20,4 +20,10 @@ public class CouponQueryServiceImpl implements CouponQueryService {
                 .orElseThrow(() -> new IllegalArgumentException(INVALID_COUPON_ID + couponId));
     }
 
+    @Override
+    public Coupon findByIdWithOptimistic(Long couponId) {
+        return couponRepository.findByIdWithOptimistic(couponId)
+                .orElseThrow(() -> new IllegalArgumentException(INVALID_COUPON_ID + couponId));
+    }
+
 }

--- a/src/main/java/com/example/book_your_seat/coupon/service/CouponQueryServiceImpl.java
+++ b/src/main/java/com/example/book_your_seat/coupon/service/CouponQueryServiceImpl.java
@@ -1,0 +1,23 @@
+package com.example.book_your_seat.coupon.service;
+
+import com.example.book_your_seat.coupon.domain.Coupon;
+import com.example.book_your_seat.coupon.repository.CouponRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import static com.example.book_your_seat.coupon.CouponConst.INVALID_COUPON_ID;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class CouponQueryServiceImpl implements CouponQueryService {
+    private final CouponRepository couponRepository;
+
+    @Override
+    public Coupon findByIdWithPessimistic(Long couponId) {
+        return couponRepository.findByIdWithPessimistic(couponId)
+                .orElseThrow(() -> new IllegalArgumentException(INVALID_COUPON_ID + couponId));
+    }
+
+}

--- a/src/main/java/com/example/book_your_seat/coupon/service/CouponQueryServiceImpl.java
+++ b/src/main/java/com/example/book_your_seat/coupon/service/CouponQueryServiceImpl.java
@@ -1,10 +1,15 @@
 package com.example.book_your_seat.coupon.service;
 
+import com.example.book_your_seat.coupon.controller.dto.UserCouponResponse;
 import com.example.book_your_seat.coupon.domain.Coupon;
 import com.example.book_your_seat.coupon.repository.CouponRepository;
+import com.example.book_your_seat.coupon.repository.UserCouponRepository;
+import com.example.book_your_seat.user.domain.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 import static com.example.book_your_seat.coupon.CouponConst.INVALID_COUPON_ID;
 
@@ -13,6 +18,7 @@ import static com.example.book_your_seat.coupon.CouponConst.INVALID_COUPON_ID;
 @RequiredArgsConstructor
 public class CouponQueryServiceImpl implements CouponQueryService {
     private final CouponRepository couponRepository;
+    private final UserCouponRepository userCouponRepository;
 
     @Override
     public Coupon findByIdWithPessimistic(Long couponId) {
@@ -26,4 +32,15 @@ public class CouponQueryServiceImpl implements CouponQueryService {
                 .orElseThrow(() -> new IllegalArgumentException(INVALID_COUPON_ID + couponId));
     }
 
+    @Override
+    public List<UserCouponResponse> getUserCoupons(User user) {
+        return userCouponRepository.findAllByUser(user).stream()
+                .map(userCoupon ->
+                        new UserCouponResponse(
+                                userCoupon.getId(),
+                                userCoupon.getCoupon().getDiscountRate(),
+                                userCoupon.getCoupon().getExpirationDate(),
+                                userCoupon.isUsed())
+                ).toList();
+    }
 }

--- a/src/test/java/com/example/book_your_seat/IntegralTestSupport.java
+++ b/src/test/java/com/example/book_your_seat/IntegralTestSupport.java
@@ -3,7 +3,6 @@ package com.example.book_your_seat;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
-public abstract class IntegerTestSupport {
-
+public abstract class IntegralTestSupport {
 
 }

--- a/src/test/java/com/example/book_your_seat/service/concert/ConcertServiceTest.java
+++ b/src/test/java/com/example/book_your_seat/service/concert/ConcertServiceTest.java
@@ -1,6 +1,6 @@
 package com.example.book_your_seat.service.concert;
 
-import com.example.book_your_seat.IntegerTestSupport;
+import com.example.book_your_seat.IntegralTestSupport;
 import com.example.book_your_seat.concert.controller.dto.AddConcertRequest;
 import com.example.book_your_seat.concert.controller.dto.ConcertResponse;
 import com.example.book_your_seat.concert.service.ConcertCommandService;
@@ -14,7 +14,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
-class ConcertServiceTest extends IntegerTestSupport {
+class ConcertServiceTest extends IntegralTestSupport {
 
     @Autowired
     private ConcertCommandService concertCommandService;

--- a/src/test/java/com/example/book_your_seat/service/concert/ConcertTest.java
+++ b/src/test/java/com/example/book_your_seat/service/concert/ConcertTest.java
@@ -1,6 +1,6 @@
 package com.example.book_your_seat.service.concert;
 
-import com.example.book_your_seat.IntegerTestSupport;
+import com.example.book_your_seat.IntegralTestSupport;
 import com.example.book_your_seat.concert.domain.Concert;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.Test;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 
-class ConcertTest extends IntegerTestSupport {
+class ConcertTest extends IntegralTestSupport {
 
     // 예매 시작 시간 검증필요..
 

--- a/src/test/java/com/example/book_your_seat/service/coupon/CouponCommandServiceImplTest.java
+++ b/src/test/java/com/example/book_your_seat/service/coupon/CouponCommandServiceImplTest.java
@@ -3,17 +3,20 @@ package com.example.book_your_seat.service.coupon;
 import com.example.book_your_seat.IntegerTestSupport;
 import com.example.book_your_seat.coupon.controller.dto.CouponCreateRequest;
 import com.example.book_your_seat.coupon.domain.Coupon;
-import com.example.book_your_seat.coupon.domain.DiscountRate;
+import com.example.book_your_seat.coupon.facade.OptimisticLockCouponFacade;
 import com.example.book_your_seat.coupon.repository.CouponRepository;
 import com.example.book_your_seat.coupon.repository.UserCouponRepository;
 import com.example.book_your_seat.coupon.service.CouponCommandServiceImpl;
-import com.example.book_your_seat.coupon.facade.OptimisticLockCouponFacade;
 import com.example.book_your_seat.user.domain.User;
 import com.example.book_your_seat.user.repository.UserRepository;
-import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
@@ -21,7 +24,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
 import static com.example.book_your_seat.coupon.domain.DiscountRate.FIVE;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @SpringBootTest
 public class CouponCommandServiceImplTest extends IntegerTestSupport {
@@ -44,18 +47,18 @@ public class CouponCommandServiceImplTest extends IntegerTestSupport {
     private final int THREAD_COUNT = 16;
 
     @BeforeEach
-    public void setUpCoupon() {
+    public void setUp() {
         testUsers = new ArrayList<>();
         for (int i = 1; i <= 100; i++) {
             testUsers.add(new User("nickname", "username", "test" + i + "@test.com", "passwordpassword"));
         }
 
         userRepository.saveAll(testUsers);
-        testCoupon = couponRepository.saveAndFlush(new Coupon(100, FIVE));
+        testCoupon = couponRepository.saveAndFlush(new Coupon(100, FIVE, LocalDate.of(2024,11,01)));
     }
 
     @AfterEach
-    public void tearDownCoupon() {
+    public void tearDown() {
         userRepository.deleteAll();
         couponRepository.deleteAll();
         userCouponRepository.deleteAll();
@@ -120,7 +123,7 @@ public class CouponCommandServiceImplTest extends IntegerTestSupport {
     @DisplayName("쿠폰을 한개 생성한다.")
     public void createCoupon() {
         //given
-        CouponCreateRequest request = new CouponCreateRequest(100, FIVE);
+        CouponCreateRequest request = new CouponCreateRequest(100, FIVE, LocalDate.of(2024,11,01));
 
         //when
         Long couponId = couponCommandServiceImpl.createCoupon(request).couponId();

--- a/src/test/java/com/example/book_your_seat/service/coupon/CouponCommandServiceImplTest.java
+++ b/src/test/java/com/example/book_your_seat/service/coupon/CouponCommandServiceImplTest.java
@@ -61,9 +61,9 @@ public class CouponCommandServiceImplTest extends IntegerTestSupport {
 
     @AfterEach
     public void tearDown() {
-        userRepository.deleteAll();
-        couponRepository.deleteAll();
         userCouponRepository.deleteAll();
+        couponRepository.deleteAll();
+        userRepository.deleteAll();
     }
 
     @Test
@@ -113,7 +113,7 @@ public class CouponCommandServiceImplTest extends IntegerTestSupport {
     }
 
     @Test
-    @DisplayName("낙관적 락을 이용하여 동시에 100명이 쿠폰 발급을 요청한다.")
+    @DisplayName("낙관적 락을 이용하여 동시에 100명이 쿠폰 발급을 요청한다.(실제 MySQL에서는 데드락 발생)")
     public void issueCouponWithOptimisticTest() throws InterruptedException {
         ExecutorService executorService = Executors.newFixedThreadPool(THREAD_COUNT);
         CountDownLatch latch = new CountDownLatch(100);
@@ -141,7 +141,7 @@ public class CouponCommandServiceImplTest extends IntegerTestSupport {
     }
 
     @Test
-    @DisplayName("낙관적 락을 이용하여 동시에 101명이 쿠폰 발급을 요청하면 1명은 쿠폰을 받지 못한다.")
+    @DisplayName("낙관적 락을 이용하여 동시에 101명이 쿠폰 발급을 요청하면 1명은 쿠폰을 받지 못한다.(실제 MySQL에서는 데드락 발생)")
     public void issueCouponWithOptimisticFailTest() throws InterruptedException {
 
         ExecutorService executorService = Executors.newFixedThreadPool(THREAD_COUNT);

--- a/src/test/java/com/example/book_your_seat/service/coupon/CouponCommandServiceImplTest.java
+++ b/src/test/java/com/example/book_your_seat/service/coupon/CouponCommandServiceImplTest.java
@@ -1,5 +1,6 @@
 package com.example.book_your_seat.service.coupon;
 
+import com.example.book_your_seat.IntegralTestSupport;
 import com.example.book_your_seat.coupon.controller.dto.CouponCreateRequest;
 import com.example.book_your_seat.coupon.domain.Coupon;
 import com.example.book_your_seat.coupon.facade.OptimisticLockCouponFacade;
@@ -13,7 +14,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
 
 import java.time.LocalDate;
 import java.util.ArrayList;
@@ -26,8 +26,7 @@ import static com.example.book_your_seat.coupon.domain.DiscountRate.FIVE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-@SpringBootTest
-public class CouponCommandServiceImplTest {
+public class CouponCommandServiceImplTest extends IntegralTestSupport {
     @Autowired
     private CouponCommandServiceImpl couponCommandServiceImpl;
 

--- a/src/test/java/com/example/book_your_seat/service/coupon/CouponCommandServiceImplTest.java
+++ b/src/test/java/com/example/book_your_seat/service/coupon/CouponCommandServiceImplTest.java
@@ -1,0 +1,78 @@
+package com.example.book_your_seat.service.coupon;
+
+import com.example.book_your_seat.IntegerTestSupport;
+import com.example.book_your_seat.coupon.domain.Coupon;
+import com.example.book_your_seat.coupon.domain.DiscountRate;
+import com.example.book_your_seat.coupon.repository.CouponRepository;
+import com.example.book_your_seat.coupon.service.CouponCommandServiceImpl;
+import com.example.book_your_seat.user.domain.User;
+import com.example.book_your_seat.user.repository.UserRepository;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+@SpringBootTest
+public class CouponCommandServiceImplTest extends IntegerTestSupport {
+    @Autowired
+    private CouponCommandServiceImpl couponCommandServiceImpl;
+
+    @Autowired
+    private CouponRepository couponRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    private List<User> testUsers;
+    private Coupon testCoupon;
+    private final int THREAD_COUNT = 16;
+
+    @BeforeEach
+    public void setUpCoupon() {
+        testUsers = new ArrayList<>();
+        for (int i = 1; i <= 100; i++) {
+            testUsers.add(new User("nickname", "username", "test" + i + "@test.com", "passwordpassword"));
+        }
+
+        userRepository.saveAll(testUsers);
+        testCoupon = couponRepository.saveAndFlush(new Coupon(100, DiscountRate.FIVE));
+    }
+
+    @AfterEach
+    public void tearDownCoupon() {
+        userRepository.deleteAll();
+        couponRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("비관적 락을 이용하여 동시에 100명이 쿠폰 발급을 요청한다.")
+    public void issueCouponWithPessimisticTest() throws InterruptedException {
+
+        ExecutorService executorService = Executors.newFixedThreadPool(THREAD_COUNT);
+        CountDownLatch latch = new CountDownLatch(testUsers.size());
+
+        long startTime = System.currentTimeMillis();
+        for (User testUser : testUsers) {
+            executorService.submit(() -> {
+                try {
+                    couponCommandServiceImpl.issueCouponWithPessimistic(testUser, testCoupon.getId());
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        latch.await();
+
+        long stopTime = System.currentTimeMillis();
+        System.out.println(stopTime - startTime + "ms");
+
+        Coupon updateCoupon = couponRepository.findById(testCoupon.getId()).orElseThrow();
+        Assertions.assertEquals(0, updateCoupon.getAmount());
+    }
+}

--- a/src/test/java/com/example/book_your_seat/service/coupon/CouponQueryServiceImplTest.java
+++ b/src/test/java/com/example/book_your_seat/service/coupon/CouponQueryServiceImplTest.java
@@ -1,5 +1,6 @@
 package com.example.book_your_seat.service.coupon;
 
+import com.example.book_your_seat.IntegralTestSupport;
 import com.example.book_your_seat.coupon.controller.dto.UserCouponResponse;
 import com.example.book_your_seat.coupon.domain.Coupon;
 import com.example.book_your_seat.coupon.domain.UserCoupon;
@@ -13,7 +14,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -23,8 +23,7 @@ import static com.example.book_your_seat.coupon.domain.DiscountRate.FIVE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-@SpringBootTest
-public class CouponQueryServiceImplTest {
+public class CouponQueryServiceImplTest extends IntegralTestSupport {
     @Autowired
     private CouponQueryServiceImpl couponQueryService;
 

--- a/src/test/java/com/example/book_your_seat/service/coupon/CouponQueryServiceImplTest.java
+++ b/src/test/java/com/example/book_your_seat/service/coupon/CouponQueryServiceImplTest.java
@@ -24,7 +24,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @SpringBootTest
-
 public class CouponQueryServiceImplTest {
     @Autowired
     private CouponQueryServiceImpl couponQueryService;
@@ -34,6 +33,7 @@ public class CouponQueryServiceImplTest {
 
     @Autowired
     private UserRepository userRepository;
+
     @Autowired
     private UserCouponRepository userCouponRepository;
 
@@ -46,14 +46,13 @@ public class CouponQueryServiceImplTest {
         testUser = userRepository.saveAndFlush(new User("nickname", "username", "email@gmail.com", "userpassword"));
         testCoupon1 = couponRepository.saveAndFlush(new Coupon(100, FIVE, LocalDate.of(2024, 11, 01)));
         testCoupon2 = couponRepository.saveAndFlush(new Coupon(200, FIFTEEN, LocalDate.of(2024, 11, 01)));
-
     }
 
     @AfterEach
     public void tearDown() {
-        userRepository.deleteAll();
-        couponRepository.deleteAll();
         userCouponRepository.deleteAll();
+        couponRepository.deleteAll();
+        userRepository.deleteAll();
     }
 
     @Test
@@ -67,9 +66,6 @@ public class CouponQueryServiceImplTest {
 
         //then
         assertEquals(2, userCouponList.size());
-
-        assertThat(userCouponList).extracting(UserCouponResponse::userCouponId)
-                .containsExactly(1L, 2L);
 
         assertThat(userCouponList).extracting(UserCouponResponse::discountRate)
                 .containsExactly(FIVE, FIFTEEN);

--- a/src/test/java/com/example/book_your_seat/service/coupon/CouponQueryServiceImplTest.java
+++ b/src/test/java/com/example/book_your_seat/service/coupon/CouponQueryServiceImplTest.java
@@ -1,0 +1,83 @@
+package com.example.book_your_seat.service.coupon;
+
+import com.example.book_your_seat.coupon.controller.dto.UserCouponResponse;
+import com.example.book_your_seat.coupon.domain.Coupon;
+import com.example.book_your_seat.coupon.domain.UserCoupon;
+import com.example.book_your_seat.coupon.repository.CouponRepository;
+import com.example.book_your_seat.coupon.repository.UserCouponRepository;
+import com.example.book_your_seat.coupon.service.CouponQueryServiceImpl;
+import com.example.book_your_seat.user.domain.User;
+import com.example.book_your_seat.user.repository.UserRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static com.example.book_your_seat.coupon.domain.DiscountRate.FIFTEEN;
+import static com.example.book_your_seat.coupon.domain.DiscountRate.FIVE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@SpringBootTest
+
+public class CouponQueryServiceImplTest {
+    @Autowired
+    private CouponQueryServiceImpl couponQueryService;
+
+    @Autowired
+    private CouponRepository couponRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+    @Autowired
+    private UserCouponRepository userCouponRepository;
+
+    private User testUser;
+    private Coupon testCoupon1;
+    private Coupon testCoupon2;
+
+    @BeforeEach
+    public void setUp() {
+        testUser = userRepository.saveAndFlush(new User("nickname", "username", "email@gmail.com", "userpassword"));
+        testCoupon1 = couponRepository.saveAndFlush(new Coupon(100, FIVE, LocalDate.of(2024, 11, 01)));
+        testCoupon2 = couponRepository.saveAndFlush(new Coupon(200, FIFTEEN, LocalDate.of(2024, 11, 01)));
+
+    }
+
+    @AfterEach
+    public void tearDown() {
+        userRepository.deleteAll();
+        couponRepository.deleteAll();
+        userCouponRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("로그인한 유저의 보유 쿠폰 목록을 조회한다.")
+    public void getUserCouponsTest() {
+        //given & when
+        userCouponRepository.save(new UserCoupon(testUser, testCoupon1));
+        userCouponRepository.save(new UserCoupon(testUser, testCoupon2));
+
+        List<UserCouponResponse> userCouponList = couponQueryService.getUserCoupons(testUser);
+
+        //then
+        assertEquals(2, userCouponList.size());
+
+        assertThat(userCouponList).extracting(UserCouponResponse::userCouponId)
+                .containsExactly(1L, 2L);
+
+        assertThat(userCouponList).extracting(UserCouponResponse::discountRate)
+                .containsExactly(FIVE, FIFTEEN);
+
+        assertThat(userCouponList).extracting(UserCouponResponse::expirationDate)
+                .containsExactly(LocalDate.of(2024, 11, 01), LocalDate.of(2024, 11, 01));
+
+        assertThat(userCouponList).extracting(UserCouponResponse::isUsed)
+                .containsExactly(false, false);
+    }
+}


### PR DESCRIPTION
<!--
  템플릿은 아직 PR 작성이 익숙하지 않으신 분들을 위해서 제공하는 가이드입니다!
  리뷰어 또는 이 PR을 보게 될 다른 사람들이 이 PR을 보는데 참고할 수 있는 내용이 있다면 포함해서 작성해주시면 됩니다.
-->

## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
 - 쿠폰 생성 (추후 관리자용으로 변경 필요합니다)
 - 내 쿠폰 조회
 - 쿠폰 발급 (비관적 락)
 - 쿠폰 발급 (낙관적 락)
 
쿠폰 발급 API Controller는 따로 구현하지 않았습니다.

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
낙관적 락의 경우 MySQL 테스트할 때 실패합니다. MySQL 자체 s-lock, x-lock 규칙 때문으로 보입니다. 
자세한 내용은 노션에 적어두었습니다~
[낙관적 락 이용 시 DeadLock 발생](https://www.notion.so/30814ce3c431472fb18c8c6326d0c29e?pvs=4)
