### PR TITLE
[FEAT] 대기열 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,9 +39,9 @@ dependencies {
 	// Redisson
 	implementation 'org.redisson:redisson-spring-boot-starter:3.33.0'
 
-	implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
-	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
-	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.5'
+	implementation "io.jsonwebtoken:jjwt-api:0.11.5"
+	runtimeOnly "io.jsonwebtoken:jjwt-impl:0.11.5"
+	runtimeOnly "io.jsonwebtoken:jjwt-jackson:0.11.5"
 
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,10 @@ dependencies {
 	// Redisson
 	implementation 'org.redisson:redisson-spring-boot-starter:3.33.0'
 
+	implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.5'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/book_your_seat/BookYourSeatApplication.java
+++ b/src/main/java/com/example/book_your_seat/BookYourSeatApplication.java
@@ -3,9 +3,11 @@ package com.example.book_your_seat;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableJpaAuditing
+@EnableScheduling
 public class BookYourSeatApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/example/book_your_seat/common/JwtUtil.java
+++ b/src/main/java/com/example/book_your_seat/common/JwtUtil.java
@@ -1,0 +1,64 @@
+package com.example.book_your_seat.common;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import java.time.Instant;
+import java.util.Date;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JwtUtil {
+
+    @Value("${jwt.secretKey}")
+    private String secretKey;
+
+    @Value("${jwt.expiration}")
+    private Long expiration;
+
+    public String generateToken(Long userId) {
+        Claims claims = Jwts.claims().setSubject(userId.toString());
+        Instant now = Instant.now();
+        Instant expirationDate = now.plusMillis(expiration);
+
+        return Jwts
+                .builder()
+                .setClaims(claims)
+                .setIssuedAt(Date.from(now))
+                .setExpiration(Date.from(expirationDate))
+                .signWith(Keys.hmacShaKeyFor(secretKey.getBytes()), SignatureAlgorithm.HS512)
+                .compact();
+    }
+
+    public Long getUserIdFromToken(String token) {
+        try {
+            Claims claims = Jwts
+                    .parserBuilder()
+                    .setSigningKey(Keys.hmacShaKeyFor(secretKey.getBytes()))
+                    .build()
+                    .parseClaimsJws(token)
+                    .getBody();
+
+            return Long.parseLong(claims.getSubject());
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    public boolean validateToken(String token) {
+        try {
+            Jwts
+                    .parserBuilder()
+                    .setSigningKey(Keys.hmacShaKeyFor(secretKey.getBytes()))
+                    .build()
+                    .parseClaimsJws(token);
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+
+}

--- a/src/main/java/com/example/book_your_seat/config/RedisConfig.java
+++ b/src/main/java/com/example/book_your_seat/config/RedisConfig.java
@@ -8,7 +8,6 @@ import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
-import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
@@ -36,7 +35,7 @@ public class RedisConfig {
         RedisTemplate<String, Object> template = new RedisTemplate<>();
         template.setConnectionFactory(connectionFactory);
         template.setKeySerializer(new StringRedisSerializer());
-        template.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+        template.setValueSerializer(new StringRedisSerializer());
         return template;
     }
 }

--- a/src/main/java/com/example/book_your_seat/coupon/facade/CouponCommandFacade.java
+++ b/src/main/java/com/example/book_your_seat/coupon/facade/CouponCommandFacade.java
@@ -1,5 +1,6 @@
 package com.example.book_your_seat.coupon.facade;
 
+import com.example.book_your_seat.aop.distributedlock.DistributedLock;
 import com.example.book_your_seat.coupon.controller.dto.CouponCreateRequest;
 import com.example.book_your_seat.coupon.controller.dto.CouponResponse;
 import com.example.book_your_seat.coupon.controller.dto.UserCouponIdResponse;
@@ -30,6 +31,7 @@ public class CouponCommandFacade implements CouponCommandService {
     }
 
     @Override
+    @DistributedLock(key = "coupon_lock")
     public UserCouponIdResponse issueCouponWithPessimistic(Long userId, Long couponId) {
         User user = userManager.getUser(userId);
         Coupon coupon = couponManager.findByIdWithPessimistic(couponId);

--- a/src/main/java/com/example/book_your_seat/queue/QueueConst.java
+++ b/src/main/java/com/example/book_your_seat/queue/QueueConst.java
@@ -1,0 +1,20 @@
+package com.example.book_your_seat.queue;
+
+public class QueueConst {
+
+    private QueueConst() { }
+
+    public static final String PROCESSING_QUEUE_KEY = "PROCESSING_QUEUE";
+    public static final String WAITING_QUEUE_KEY = "WAITING_QUEUE";
+
+    public static final String ALREADY_IN_QUEUE_KEY = "이미 대기열에 있습니다.";
+
+    public static final String DELIMITER = ":";
+
+    public static final Long ZERO = 0L;
+    public static final Long FIVE = 5L;
+    public static final Long MINUTE = 60L;
+    public static final Long ALLOWED_PROCESSING_SIZE = 1000L;
+    public static final Long FIFTEEN_MINUTE = 1000 * 60 * 15L;
+
+}

--- a/src/main/java/com/example/book_your_seat/queue/controller/QueueController.java
+++ b/src/main/java/com/example/book_your_seat/queue/controller/QueueController.java
@@ -1,0 +1,32 @@
+package com.example.book_your_seat.queue.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/queue")
+@RequiredArgsConstructor
+public class QueueController {
+
+    @PostMapping("/users/{userId}")
+    public ResponseEntity<Void> issueQueueToken(@PathVariable("userId") Long userId) {
+        return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("/users")
+    public ResponseEntity<Void> getTokenStatus(String token) {
+        return ResponseEntity.ok().build();
+    }
+
+    @DeleteMapping("/users")
+    public ResponseEntity<Void> deleteQueueToken(String token) {
+        return ResponseEntity.ok().build();
+    }
+
+}

--- a/src/main/java/com/example/book_your_seat/queue/controller/QueueController.java
+++ b/src/main/java/com/example/book_your_seat/queue/controller/QueueController.java
@@ -1,5 +1,6 @@
 package com.example.book_your_seat.queue.controller;
 
+import com.example.book_your_seat.queue.controller.dto.QueueResponse;
 import com.example.book_your_seat.queue.controller.dto.QueueToken;
 import com.example.book_your_seat.queue.service.QueueService;
 import lombok.RequiredArgsConstructor;
@@ -9,6 +10,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -26,10 +28,10 @@ public class QueueController {
     }
 
     @GetMapping("/users")
-    public ResponseEntity<Void> getTokenStatus(String token) {
+    public ResponseEntity<QueueResponse> getTokenStatus(@RequestParam("token") String token) {
         return ResponseEntity
                 .ok()
-                .build();
+                .body(queueService.findQueueByToken(token));
     }
 
     @DeleteMapping("/users")

--- a/src/main/java/com/example/book_your_seat/queue/controller/QueueController.java
+++ b/src/main/java/com/example/book_your_seat/queue/controller/QueueController.java
@@ -35,7 +35,7 @@ public class QueueController {
     }
 
     @DeleteMapping("/users")
-    public ResponseEntity<Void> deleteQueueToken(String token) {
+    public ResponseEntity<Void> deleteQueueToken(@RequestParam("token")String token) {
         queueService.deleteQueueToken(token);
         return ResponseEntity
                 .ok()

--- a/src/main/java/com/example/book_your_seat/queue/controller/QueueController.java
+++ b/src/main/java/com/example/book_your_seat/queue/controller/QueueController.java
@@ -36,6 +36,7 @@ public class QueueController {
 
     @DeleteMapping("/users")
     public ResponseEntity<Void> deleteQueueToken(String token) {
+        queueService.deleteQueueToken(token);
         return ResponseEntity
                 .ok()
                 .build();

--- a/src/main/java/com/example/book_your_seat/queue/controller/QueueController.java
+++ b/src/main/java/com/example/book_your_seat/queue/controller/QueueController.java
@@ -1,5 +1,7 @@
 package com.example.book_your_seat.queue.controller;
 
+import com.example.book_your_seat.queue.controller.dto.QueueToken;
+import com.example.book_your_seat.queue.service.QueueService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -14,19 +16,27 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class QueueController {
 
+    private final QueueService queueService;
+
     @PostMapping("/users/{userId}")
-    public ResponseEntity<Void> issueQueueToken(@PathVariable("userId") Long userId) {
-        return ResponseEntity.ok().build();
+    public ResponseEntity<QueueToken> issueQueueToken(@PathVariable("userId") Long userId) {
+        return ResponseEntity
+                .ok()
+                .body(queueService.issueQueueToken(userId));
     }
 
     @GetMapping("/users")
     public ResponseEntity<Void> getTokenStatus(String token) {
-        return ResponseEntity.ok().build();
+        return ResponseEntity
+                .ok()
+                .build();
     }
 
     @DeleteMapping("/users")
     public ResponseEntity<Void> deleteQueueToken(String token) {
-        return ResponseEntity.ok().build();
+        return ResponseEntity
+                .ok()
+                .build();
     }
 
 }

--- a/src/main/java/com/example/book_your_seat/queue/controller/dto/QueueResponse.java
+++ b/src/main/java/com/example/book_your_seat/queue/controller/dto/QueueResponse.java
@@ -1,0 +1,17 @@
+package com.example.book_your_seat.queue.controller.dto;
+
+import com.example.book_your_seat.queue.domain.QueueStatus;
+
+public record QueueResponse(
+        QueueStatus status,
+        Long remainingWaitingCount,
+        Long estimatedWaitTime
+) {
+    public static QueueResponse processing() {
+        return new QueueResponse(QueueStatus.PROCESSING, 0L, 0L);
+    }
+
+    public static QueueResponse waiting(Long position, Long estimatedWaitTime) {
+        return new QueueResponse(QueueStatus.WAITING, position, estimatedWaitTime);
+    }
+}

--- a/src/main/java/com/example/book_your_seat/queue/controller/dto/QueueResponse.java
+++ b/src/main/java/com/example/book_your_seat/queue/controller/dto/QueueResponse.java
@@ -1,6 +1,8 @@
 package com.example.book_your_seat.queue.controller.dto;
 
-import com.example.book_your_seat.queue.domain.QueueStatus;
+import static com.example.book_your_seat.queue.QueueConst.ZERO;
+
+import com.example.book_your_seat.queue.util.QueueStatus;
 
 public record QueueResponse(
         QueueStatus status,
@@ -8,7 +10,7 @@ public record QueueResponse(
         Long estimatedWaitTime
 ) {
     public static QueueResponse processing() {
-        return new QueueResponse(QueueStatus.PROCESSING, 0L, 0L);
+        return new QueueResponse(QueueStatus.PROCESSING, ZERO, ZERO);
     }
 
     public static QueueResponse waiting(Long position, Long estimatedWaitTime) {

--- a/src/main/java/com/example/book_your_seat/queue/controller/dto/QueueResponse.java
+++ b/src/main/java/com/example/book_your_seat/queue/controller/dto/QueueResponse.java
@@ -16,4 +16,8 @@ public record QueueResponse(
     public static QueueResponse waiting(Long position, Long estimatedWaitTime) {
         return new QueueResponse(QueueStatus.WAITING, position, estimatedWaitTime);
     }
+
+    public static QueueResponse cancel() {
+        return new QueueResponse(QueueStatus.CANCELED, ZERO, ZERO);
+    }
 }

--- a/src/main/java/com/example/book_your_seat/queue/controller/dto/QueueToken.java
+++ b/src/main/java/com/example/book_your_seat/queue/controller/dto/QueueToken.java
@@ -1,0 +1,6 @@
+package com.example.book_your_seat.queue.controller.dto;
+
+public record QueueToken (
+        String token
+) {
+}

--- a/src/main/java/com/example/book_your_seat/queue/domain/QueueStatus.java
+++ b/src/main/java/com/example/book_your_seat/queue/domain/QueueStatus.java
@@ -1,0 +1,8 @@
+package com.example.book_your_seat.queue.domain;
+
+public enum QueueStatus {
+    WAITING,
+    PROCESSING,
+    COMPLETED,
+    CANCELED
+}

--- a/src/main/java/com/example/book_your_seat/queue/manager/QueueManager.java
+++ b/src/main/java/com/example/book_your_seat/queue/manager/QueueManager.java
@@ -49,4 +49,8 @@ public class QueueManager {
         return batches * batchInterval;
     }
 
+    public void removeToken(String token) {
+        redisQueueRepository.removeWaitingToken(token);
+        redisQueueRepository.removeProcessingToken(token);
+    }
 }

--- a/src/main/java/com/example/book_your_seat/queue/manager/QueueManager.java
+++ b/src/main/java/com/example/book_your_seat/queue/manager/QueueManager.java
@@ -1,0 +1,23 @@
+package com.example.book_your_seat.queue.manager;
+
+import com.example.book_your_seat.common.JwtUtil;
+import com.example.book_your_seat.queue.repository.RedisQueueRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class QueueManager {
+
+    private final JwtUtil jwtUtil;
+    private final RedisQueueRepository redisQueueRepository;
+
+    public String enqueueToken(Long userId) {
+        String token = jwtUtil.generateToken(userId);
+        Long score = System.currentTimeMillis();
+
+        redisQueueRepository.addToWaitingQueue(token, score);
+        return token;
+    }
+
+}

--- a/src/main/java/com/example/book_your_seat/queue/repository/RedisQueueRepository.java
+++ b/src/main/java/com/example/book_your_seat/queue/repository/RedisQueueRepository.java
@@ -1,0 +1,17 @@
+package com.example.book_your_seat.queue.repository;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class RedisQueueRepository {
+
+    private final RedisTemplate<String, String> redisTemplate;
+
+    public void addToWaitingQueue(String token, Long score) {
+        System.out.println("score = " + score);
+        redisTemplate.opsForZSet().add("WAITING_QUEUE_KEY", token, score.doubleValue());
+    }
+}

--- a/src/main/java/com/example/book_your_seat/queue/repository/RedisQueueRepository.java
+++ b/src/main/java/com/example/book_your_seat/queue/repository/RedisQueueRepository.java
@@ -1,5 +1,6 @@
 package com.example.book_your_seat.queue.repository;
 
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Repository;
@@ -10,17 +11,42 @@ public class RedisQueueRepository {
 
     private final RedisTemplate<String, String> redisTemplate;
 
-    public void addToWaitingQueue(String token, Long score) {
-        redisTemplate.opsForZSet().add("WAITING_QUEUE", token, score.doubleValue());
+    public void addToWaitingQueue(String token, Long userId, Long score) {
+
+        System.out.println("token + \":\" + userId = " + token + ":" + userId);
+
+        if (haveSpaceInProcessingQueue()) {
+            redisTemplate.opsForZSet().add("PROCESSING_QUEUE", token + ":" + userId, score.doubleValue());
+            return;
+        }
+        redisTemplate.opsForZSet().add("WAITING_QUEUE", token + ":" + userId, score.doubleValue());
     }
 
-    public boolean isProcessingQueue(String token) {
-        Double score = redisTemplate.opsForZSet().score("PROCESSING_QUEUE", token);
+    private boolean haveSpaceInProcessingQueue() {
+        Long size = redisTemplate.opsForZSet().size("PROCESSING_QUEUE");
+        if (size == null) {
+            return true;
+        }
+        return size < 1000L;
+    }
+
+    public boolean isProcessingQueue(String token, Long userId) {
+        Double score = redisTemplate.opsForZSet().score("PROCESSING_QUEUE", token + ":" + userId);
         return score != null;
     }
 
     public long getWaitingQueuePosition(String token, String userId) {
-        Long rank = redisTemplate.opsForZSet().rank("WAITING_QUEUE", token);
+        Long rank = redisTemplate.opsForZSet().rank("WAITING_QUEUE", token + ":" + userId);
         return rank != null ? rank : -1;
+    }
+
+    public boolean alreadyEnQueued(Long userId) {
+        String pattern = ":" + userId;
+        return isUserInQueue("WAITING_QUEUE", pattern) || isUserInQueue("PROCESSING_QUEUE", pattern);
+    }
+
+    private boolean isUserInQueue(String queueName, String pattern) {
+        Set<String> queueEntries = redisTemplate.opsForZSet().range(queueName, 0, -1);
+        return queueEntries != null && queueEntries.stream().anyMatch(entry -> entry.endsWith(pattern));
     }
 }

--- a/src/main/java/com/example/book_your_seat/queue/repository/RedisQueueRepository.java
+++ b/src/main/java/com/example/book_your_seat/queue/repository/RedisQueueRepository.java
@@ -1,5 +1,6 @@
 package com.example.book_your_seat.queue.repository;
 
+import java.util.Collections;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -48,5 +49,23 @@ public class RedisQueueRepository {
     private boolean isUserInQueue(String queueName, String pattern) {
         Set<String> queueEntries = redisTemplate.opsForZSet().range(queueName, 0, -1);
         return queueEntries != null && queueEntries.stream().anyMatch(entry -> entry.endsWith(pattern));
+    }
+
+    public Set<String> getWaitingQueueNeedToUpdateToProcessing(int needToUpdateCount) {
+        Set<String> range = redisTemplate
+                .opsForZSet()
+                .range("WAITING_QUEUE", 0, needToUpdateCount - 1);
+
+        return range != null ? range : Collections.emptySet();
+    }
+
+    public void updateToProcessingQueue(String token, long expirationTime) {
+        redisTemplate.opsForZSet().remove("WAITING_QUEUE", token);
+        redisTemplate.opsForZSet().add("PROCESSING_QUEUE", token, (double) expirationTime);
+    }
+
+    public Long getProcessingQueueCount() {
+        Long size = redisTemplate.opsForZSet().size("PROCESSING_QUEUE");
+        return size != null ? size : 0L;
     }
 }

--- a/src/main/java/com/example/book_your_seat/queue/repository/RedisQueueRepository.java
+++ b/src/main/java/com/example/book_your_seat/queue/repository/RedisQueueRepository.java
@@ -11,7 +11,16 @@ public class RedisQueueRepository {
     private final RedisTemplate<String, String> redisTemplate;
 
     public void addToWaitingQueue(String token, Long score) {
-        System.out.println("score = " + score);
-        redisTemplate.opsForZSet().add("WAITING_QUEUE_KEY", token, score.doubleValue());
+        redisTemplate.opsForZSet().add("WAITING_QUEUE", token, score.doubleValue());
+    }
+
+    public boolean isProcessingQueue(String token) {
+        Double score = redisTemplate.opsForZSet().score("PROCESSING_QUEUE", token);
+        return score != null;
+    }
+
+    public long getWaitingQueuePosition(String token, String userId) {
+        Long rank = redisTemplate.opsForZSet().rank("WAITING_QUEUE", token);
+        return rank != null ? rank : -1;
     }
 }

--- a/src/main/java/com/example/book_your_seat/queue/repository/RedisQueueRepository.java
+++ b/src/main/java/com/example/book_your_seat/queue/repository/RedisQueueRepository.java
@@ -1,5 +1,11 @@
 package com.example.book_your_seat.queue.repository;
 
+import static com.example.book_your_seat.queue.QueueConst.ALLOWED_PROCESSING_SIZE;
+import static com.example.book_your_seat.queue.QueueConst.DELIMITER;
+import static com.example.book_your_seat.queue.QueueConst.PROCESSING_QUEUE_KEY;
+import static com.example.book_your_seat.queue.QueueConst.WAITING_QUEUE_KEY;
+import static com.example.book_your_seat.queue.QueueConst.ZERO;
+
 import java.util.Collections;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
@@ -14,78 +20,80 @@ public class RedisQueueRepository {
 
     public void addToWaitingQueue(String token, Long userId, Long score) {
 
-        System.out.println("token + \":\" + userId = " + token + ":" + userId);
-
         if (haveSpaceInProcessingQueue()) {
-            redisTemplate.opsForZSet().add("PROCESSING_QUEUE", token + ":" + userId, score.doubleValue());
+            redisTemplate.opsForZSet().add(PROCESSING_QUEUE_KEY, makeValue(token, userId), score.doubleValue());
             return;
         }
-        redisTemplate.opsForZSet().add("WAITING_QUEUE", token + ":" + userId, score.doubleValue());
+        redisTemplate.opsForZSet().add(WAITING_QUEUE_KEY, makeValue(token, userId), score.doubleValue());
     }
 
     private boolean haveSpaceInProcessingQueue() {
-        Long size = redisTemplate.opsForZSet().size("PROCESSING_QUEUE");
+        Long size = redisTemplate.opsForZSet().size(PROCESSING_QUEUE_KEY);
         if (size == null) {
             return true;
         }
-        return size < 1000L;
+        return size < ALLOWED_PROCESSING_SIZE;
     }
 
     public boolean isProcessingQueue(String token, Long userId) {
-        Double score = redisTemplate.opsForZSet().score("PROCESSING_QUEUE", token + ":" + userId);
+        Double score = redisTemplate.opsForZSet().score(PROCESSING_QUEUE_KEY, makeValue(token, userId));
         return score != null;
     }
 
-    public long getWaitingQueuePosition(String token, String userId) {
-        Long rank = redisTemplate.opsForZSet().rank("WAITING_QUEUE", token + ":" + userId);
+    public long getWaitingQueuePosition(String token, Long userId) {
+        Long rank = redisTemplate.opsForZSet().rank(WAITING_QUEUE_KEY, makeValue(token, userId));
         return rank != null ? rank : -1;
     }
 
+    private String makeValue(String token, Long userId) {
+        return token + DELIMITER + userId;
+    }
+
     public boolean alreadyEnQueued(Long userId) {
-        String pattern = ":" + userId;
-        return isUserInQueue("WAITING_QUEUE", pattern) || isUserInQueue("PROCESSING_QUEUE", pattern);
+        String pattern = DELIMITER + userId;
+        return isUserInQueue(WAITING_QUEUE_KEY, pattern) || isUserInQueue(PROCESSING_QUEUE_KEY, pattern);
     }
 
     private boolean isUserInQueue(String queueName, String pattern) {
-        Set<String> queueEntries = redisTemplate.opsForZSet().range(queueName, 0, -1);
+        Set<String> queueEntries = redisTemplate.opsForZSet().range(queueName, ZERO, -1);
         return queueEntries != null && queueEntries.stream().anyMatch(entry -> entry.endsWith(pattern));
     }
 
     public Set<String> getWaitingQueueNeedToUpdateToProcessing(int needToUpdateCount) {
         Set<String> range = redisTemplate
                 .opsForZSet()
-                .range("WAITING_QUEUE", 0, needToUpdateCount - 1);
+                .range(WAITING_QUEUE_KEY, ZERO, needToUpdateCount - 1);
 
         return range != null ? range : Collections.emptySet();
     }
 
     public void updateToProcessingQueue(String token, long expirationTime) {
-        redisTemplate.opsForZSet().remove("WAITING_QUEUE", token);
-        redisTemplate.opsForZSet().add("PROCESSING_QUEUE", token, (double) expirationTime);
+        redisTemplate.opsForZSet().remove(WAITING_QUEUE_KEY, token);
+        redisTemplate.opsForZSet().add(PROCESSING_QUEUE_KEY, token, (double) expirationTime);
     }
 
     public Long getProcessingQueueCount() {
-        Long size = redisTemplate.opsForZSet().size("PROCESSING_QUEUE");
-        return size != null ? size : 0L;
+        Long size = redisTemplate.opsForZSet().size(PROCESSING_QUEUE_KEY);
+        return size != null ? size : ZERO;
     }
 
     public void removeProcessingToken(String token) {
-        Set<String> members = redisTemplate.opsForSet().members("PROCESSING_QUEUE");
+        Set<String> members = redisTemplate.opsForSet().members(PROCESSING_QUEUE_KEY);
         if (members != null) {
             members.stream()
                     .filter(entry -> entry.startsWith(token))
                     .findFirst()
-                    .ifPresent(entry -> redisTemplate.opsForSet().remove("PROCESSING_QUEUE", entry));
+                    .ifPresent(entry -> redisTemplate.opsForSet().remove(PROCESSING_QUEUE_KEY, entry));
         }
     }
 
     public void removeWaitingToken(String token) {
-        Set<String> members = redisTemplate.opsForSet().members("WAITING_QUEUE");
+        Set<String> members = redisTemplate.opsForSet().members(WAITING_QUEUE_KEY);
         if (members != null) {
             members.stream()
                     .filter(entry -> entry.startsWith(token))
                     .findFirst()
-                    .ifPresent(entry -> redisTemplate.opsForSet().remove("WAITING_QUEUE", entry));
+                    .ifPresent(entry -> redisTemplate.opsForSet().remove(WAITING_QUEUE_KEY, entry));
         }
     }
 }

--- a/src/main/java/com/example/book_your_seat/queue/repository/RedisQueueRepository.java
+++ b/src/main/java/com/example/book_your_seat/queue/repository/RedisQueueRepository.java
@@ -68,4 +68,24 @@ public class RedisQueueRepository {
         Long size = redisTemplate.opsForZSet().size("PROCESSING_QUEUE");
         return size != null ? size : 0L;
     }
+
+    public void removeProcessingToken(String token) {
+        Set<String> members = redisTemplate.opsForSet().members("PROCESSING_QUEUE");
+        if (members != null) {
+            members.stream()
+                    .filter(entry -> entry.startsWith(token))
+                    .findFirst()
+                    .ifPresent(entry -> redisTemplate.opsForSet().remove("PROCESSING_QUEUE", entry));
+        }
+    }
+
+    public void removeWaitingToken(String token) {
+        Set<String> members = redisTemplate.opsForSet().members("WAITING_QUEUE");
+        if (members != null) {
+            members.stream()
+                    .filter(entry -> entry.startsWith(token))
+                    .findFirst()
+                    .ifPresent(entry -> redisTemplate.opsForSet().remove("WAITING_QUEUE", entry));
+        }
+    }
 }

--- a/src/main/java/com/example/book_your_seat/queue/service/QueueScheduler.java
+++ b/src/main/java/com/example/book_your_seat/queue/service/QueueScheduler.java
@@ -4,7 +4,6 @@ import static com.example.book_your_seat.queue.QueueConst.ALLOWED_PROCESSING_SIZ
 import static com.example.book_your_seat.queue.QueueConst.FIFTEEN_MINUTE;
 import static com.example.book_your_seat.queue.QueueConst.ZERO;
 
-import com.example.book_your_seat.common.JwtUtil;
 import com.example.book_your_seat.queue.repository.RedisQueueRepository;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
@@ -18,7 +17,6 @@ import org.springframework.stereotype.Component;
 public class QueueScheduler {
 
     private final RedisQueueRepository redisQueueRepository;
-    private final JwtUtil jwtUtil;
 
     @Scheduled(fixedRate = 30000)
     public void updateQueueStatus() {

--- a/src/main/java/com/example/book_your_seat/queue/service/QueueScheduler.java
+++ b/src/main/java/com/example/book_your_seat/queue/service/QueueScheduler.java
@@ -1,0 +1,40 @@
+package com.example.book_your_seat.queue.service;
+
+import com.example.book_your_seat.queue.repository.RedisQueueRepository;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class QueueScheduler {
+
+    private final RedisQueueRepository redisQueueRepository;
+
+    @Scheduled(fixedRate = 30000)
+    public void updateQueueStatus() {
+        Long availableProcessingRoom = calculateAvailableProcessingRoom();
+        if (availableProcessingRoom <= 0) return;
+
+        Set<String> tokensNeedToUpdateToProcessing =
+                redisQueueRepository.getWaitingQueueNeedToUpdateToProcessing(availableProcessingRoom.intValue());
+
+        for (String token : tokensNeedToUpdateToProcessing) {
+            try {
+                redisQueueRepository.updateToProcessingQueue(
+                        token,
+                        System.currentTimeMillis() + 900000
+                );
+            } catch (Exception e) {
+                System.err.println("Error updating token to processing: " + e.getMessage());
+            }
+        }
+    }
+
+    private Long calculateAvailableProcessingRoom() {
+        Long currentProcessingCount = redisQueueRepository.getProcessingQueueCount();
+        return 1000 - currentProcessingCount;
+    }
+
+}

--- a/src/main/java/com/example/book_your_seat/queue/service/QueueScheduler.java
+++ b/src/main/java/com/example/book_your_seat/queue/service/QueueScheduler.java
@@ -4,6 +4,7 @@ import static com.example.book_your_seat.queue.QueueConst.ALLOWED_PROCESSING_SIZ
 import static com.example.book_your_seat.queue.QueueConst.FIFTEEN_MINUTE;
 import static com.example.book_your_seat.queue.QueueConst.ZERO;
 
+import com.example.book_your_seat.common.JwtUtil;
 import com.example.book_your_seat.queue.repository.RedisQueueRepository;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
@@ -17,15 +18,17 @@ import org.springframework.stereotype.Component;
 public class QueueScheduler {
 
     private final RedisQueueRepository redisQueueRepository;
+    private final JwtUtil jwtUtil;
 
     @Scheduled(fixedRate = 30000)
     public void updateQueueStatus() {
         Long availableProcessingRoom = calculateAvailableProcessingRoom();
         if (availableProcessingRoom <= ZERO) return;
+        System.out.println("availableProcessingRoom: "+availableProcessingRoom);
 
         Set<String> tokensNeedToUpdateToProcessing =
                 redisQueueRepository.getWaitingQueueNeedToUpdateToProcessing(availableProcessingRoom.intValue());
-
+        System.out.println(tokensNeedToUpdateToProcessing.size());
         for (String token : tokensNeedToUpdateToProcessing) {
             try {
                 redisQueueRepository.updateToProcessingQueue(

--- a/src/main/java/com/example/book_your_seat/queue/service/QueueScheduler.java
+++ b/src/main/java/com/example/book_your_seat/queue/service/QueueScheduler.java
@@ -22,11 +22,9 @@ public class QueueScheduler {
     public void updateQueueStatus() {
         Long availableProcessingRoom = calculateAvailableProcessingRoom();
         if (availableProcessingRoom <= ZERO) return;
-        System.out.println("availableProcessingRoom: "+availableProcessingRoom);
 
         Set<String> tokensNeedToUpdateToProcessing =
                 redisQueueRepository.getWaitingQueueNeedToUpdateToProcessing(availableProcessingRoom.intValue());
-        System.out.println(tokensNeedToUpdateToProcessing.size());
         for (String token : tokensNeedToUpdateToProcessing) {
             try {
                 redisQueueRepository.updateToProcessingQueue(

--- a/src/main/java/com/example/book_your_seat/queue/service/QueueService.java
+++ b/src/main/java/com/example/book_your_seat/queue/service/QueueService.java
@@ -1,0 +1,22 @@
+package com.example.book_your_seat.queue.service;
+
+import com.example.book_your_seat.queue.controller.dto.QueueToken;
+import com.example.book_your_seat.queue.manager.QueueManager;
+import com.example.book_your_seat.user.manager.UserManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class QueueService {
+
+    private final QueueManager queueManager;
+    private final UserManager userManager;
+
+    public QueueToken issueQueueToken(Long userId) {
+
+        userManager.checkUser(userId);
+
+        return new QueueToken(queueManager.enqueueToken(userId));
+    }
+}

--- a/src/main/java/com/example/book_your_seat/queue/service/QueueService.java
+++ b/src/main/java/com/example/book_your_seat/queue/service/QueueService.java
@@ -29,6 +29,10 @@ public class QueueService {
             return QueueResponse.processing();
         }
 
+        if (status == QueueStatus.CANCELED) {
+            return QueueResponse.cancel();
+        }
+
         Long position = queueManager.getPositionInWaitingStatus(token);
         Long estimatedWaitTime = queueManager.calculateEstimatedWaitSeconds(position);
 
@@ -36,6 +40,7 @@ public class QueueService {
     }
 
     public void deleteQueueToken(String token) {
-        queueManager.removeToken(token);
+        QueueStatus status = queueManager.getQueueStatus(token);
+        queueManager.removeToken(status, token);
     }
 }

--- a/src/main/java/com/example/book_your_seat/queue/service/QueueService.java
+++ b/src/main/java/com/example/book_your_seat/queue/service/QueueService.java
@@ -2,7 +2,7 @@ package com.example.book_your_seat.queue.service;
 
 import com.example.book_your_seat.queue.controller.dto.QueueResponse;
 import com.example.book_your_seat.queue.controller.dto.QueueToken;
-import com.example.book_your_seat.queue.domain.QueueStatus;
+import com.example.book_your_seat.queue.util.QueueStatus;
 import com.example.book_your_seat.queue.manager.QueueManager;
 import com.example.book_your_seat.user.manager.UserManager;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/example/book_your_seat/queue/service/QueueService.java
+++ b/src/main/java/com/example/book_your_seat/queue/service/QueueService.java
@@ -34,4 +34,8 @@ public class QueueService {
 
         return QueueResponse.waiting(position, estimatedWaitTime);
     }
+
+    public void deleteQueueToken(String token) {
+        queueManager.removeToken(token);
+    }
 }

--- a/src/main/java/com/example/book_your_seat/queue/service/QueueService.java
+++ b/src/main/java/com/example/book_your_seat/queue/service/QueueService.java
@@ -1,6 +1,8 @@
 package com.example.book_your_seat.queue.service;
 
+import com.example.book_your_seat.queue.controller.dto.QueueResponse;
 import com.example.book_your_seat.queue.controller.dto.QueueToken;
+import com.example.book_your_seat.queue.domain.QueueStatus;
 import com.example.book_your_seat.queue.manager.QueueManager;
 import com.example.book_your_seat.user.manager.UserManager;
 import lombok.RequiredArgsConstructor;
@@ -18,5 +20,18 @@ public class QueueService {
         userManager.checkUser(userId);
 
         return new QueueToken(queueManager.enqueueToken(userId));
+    }
+
+    public QueueResponse findQueueByToken(String token) {
+        QueueStatus status = queueManager.getQueueStatus(token);
+
+        if (status == QueueStatus.PROCESSING) {
+            return QueueResponse.processing();
+        }
+
+        Long position = queueManager.getPositionInWaitingStatus(token);
+        Long estimatedWaitTime = queueManager.calculateEstimatedWaitSeconds(position);
+
+        return QueueResponse.waiting(position, estimatedWaitTime);
     }
 }

--- a/src/main/java/com/example/book_your_seat/queue/util/QueueStatus.java
+++ b/src/main/java/com/example/book_your_seat/queue/util/QueueStatus.java
@@ -1,4 +1,4 @@
-package com.example.book_your_seat.queue.domain;
+package com.example.book_your_seat.queue.util;
 
 public enum QueueStatus {
     WAITING,

--- a/src/main/java/com/example/book_your_seat/user/manager/UserManager.java
+++ b/src/main/java/com/example/book_your_seat/user/manager/UserManager.java
@@ -25,4 +25,9 @@ public class UserManager {
                 .orElseThrow(() -> new IllegalArgumentException(USER_NOT_FOUND));
     }
 
+    public void checkUser(Long userId) {
+        if (!userRepository.existsById(userId)) {
+            throw new IllegalArgumentException("User not found");
+        }
+    }
 }

--- a/src/main/java/com/example/book_your_seat/user/manager/UserManager.java
+++ b/src/main/java/com/example/book_your_seat/user/manager/UserManager.java
@@ -30,8 +30,4 @@ public class UserManager {
             throw new IllegalArgumentException("User not found");
         }
     }
-
-    public User createUser(User user) {
-        return userRepository.save(user);
-    }
 }

--- a/src/main/java/com/example/book_your_seat/user/manager/UserManager.java
+++ b/src/main/java/com/example/book_your_seat/user/manager/UserManager.java
@@ -30,4 +30,8 @@ public class UserManager {
             throw new IllegalArgumentException("User not found");
         }
     }
+
+    public User createUser(User user) {
+        return userRepository.save(user);
+    }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -12,8 +12,21 @@ spring:
         format_sql: true
     hibernate:
       ddl-auto: create
+  redis:
+    host: localhost
+    port: 6379
+    password:
+
+server:
+  tomcat:
+    threads:
+      min-spare: 50
 
 logging:
   level:
     ROOT: INFO
     org.springframework.web.filter.CommonsRequestLoggingFilter: DEBUG
+
+jwt:
+  secretKey: concert_jwt_secretconcert_jwt_secretconcert_jwt_secretconcert_jwt_secretconcert_jwt_secret
+  expiration: 1800000

--- a/src/test/java/com/example/book_your_seat/service/queue/QueueServiceTest.java
+++ b/src/test/java/com/example/book_your_seat/service/queue/QueueServiceTest.java
@@ -3,12 +3,15 @@ package com.example.book_your_seat.service.queue;
 import static org.assertj.core.api.Assertions.*;
 
 import com.example.book_your_seat.IntegerTestSupport;
+import com.example.book_your_seat.queue.controller.dto.QueueResponse;
 import com.example.book_your_seat.queue.controller.dto.QueueToken;
-import com.example.book_your_seat.queue.manager.QueueManager;
-import com.example.book_your_seat.queue.repository.RedisQueueRepository;
+import com.example.book_your_seat.queue.service.QueueScheduler;
 import com.example.book_your_seat.queue.service.QueueService;
+import com.example.book_your_seat.queue.util.QueueStatus;
 import com.example.book_your_seat.user.domain.User;
-import com.example.book_your_seat.user.manager.UserManager;
+import com.example.book_your_seat.user.repository.UserRepository;
+import java.util.ArrayList;
+import java.util.List;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -22,41 +25,145 @@ public class QueueServiceTest extends IntegerTestSupport {
     private QueueService queueService;
 
     @Autowired
-    private QueueManager queueManager;
-
-    @Autowired
-    private UserManager userManager;
-
-    @Autowired
-    RedisQueueRepository redisQueueRepository;
+    private UserRepository userRepository;
 
     @Autowired
     private RedisTemplate<String, String> redisTemplate;
+
+    @Autowired
+    private QueueScheduler queueScheduler;
 
     private User savedUser;
 
     @BeforeEach
     void beforeEach() {
-        savedUser = userManager.createUser(new User("nickname", "username", "email@email.com", "passwordpassowrd"));
+        savedUser = userRepository.save(new User("nickname", "username", "email@email.com", "passwordpassowrd"));
+        for (int i = 0; i < 1100; i++) {
+            userRepository.save(new User("nickname", "username", "email@email.com", "passwordpassowrd"));
+        }
     }
 
     @AfterEach
     void afterEach() {
         redisTemplate.getConnectionFactory().getConnection().flushAll();
+        userRepository.deleteAll();
     }
 
     @Test
-    @DisplayName("")
+    @DisplayName("대기열 진입을 시도하면 대기열에 저장되고, 토큰을 반환한다.")
     void issueTokenTest() {
         // given
         Long userId = savedUser.getId();
-        System.out.println(userId);
 
         // when
         QueueToken queueToken = queueService.issueQueueToken(userId);
 
         // then
         assertThat(queueToken).isNotNull();
+    }
+
+    @Test
+    @DisplayName("PROCESSING QUEUE가 가득 차기 전까지 PROCESSING QUEUE에 저장된다.")
+    void issueTokenInProcessingQueueTest() {
+        //given
+        Long userId = savedUser.getId();
+        QueueToken queueToken = queueService.issueQueueToken(userId);
+
+        //when
+        QueueResponse queueResponse = queueService.findQueueByToken(queueToken.token());
+
+        //then
+        assertThat(queueResponse).isNotNull();
+        assertThat(queueResponse.status()).isEqualTo(QueueStatus.PROCESSING);
+        assertThat(queueResponse.remainingWaitingCount()).isEqualTo(0L);
+        assertThat(queueResponse.estimatedWaitTime()).isEqualTo(0L);
+    }
+
+    @Test
+    @DisplayName("PROCESSING QUEUE가 가득 차면 WAITING QUEUE에 저장된다.")
+    void issueTokenWaitingQueueTest() {
+        //given
+        List<User> all = userRepository.findAll();
+        for (int i = 0; i < all.size() - 1; i++) {
+            Long userId = all.get(i).getId();
+            queueService.issueQueueToken(userId);
+        }
+
+        Long id = all.get(all.size() - 1).getId();
+        QueueToken queueToken = queueService.issueQueueToken(id);
+
+        //when
+        QueueResponse queueResponse = queueService.findQueueByToken(queueToken.token());
+
+        //then
+        assertThat(queueResponse).isNotNull();
+        assertThat(queueResponse.status()).isEqualTo(QueueStatus.WAITING);
+        assertThat(queueResponse.remainingWaitingCount()).isEqualTo(100L);
+        assertThat(queueResponse.estimatedWaitTime()).isEqualTo(0L);
+    }
+
+    @Test
+    @DisplayName("토큰을 통해서 대기열에서 삭제할 수 있다")
+    void deleteQueueByTokenTest() {
+        //given
+        Long userId = savedUser.getId();
+        QueueToken queueToken = queueService.issueQueueToken(userId);
+
+        //when
+        queueService.deleteQueueToken(queueToken.token());
+
+        QueueResponse queueResponse = queueService.findQueueByToken(queueToken.token());
+
+        //then
+        assertThat(queueResponse).isNotNull();
+        assertThat(queueResponse.status()).isEqualTo(QueueStatus.CANCELED);
+        assertThat(queueResponse.remainingWaitingCount()).isEqualTo(0L);
+        assertThat(queueResponse.estimatedWaitTime()).isEqualTo(0L);
+    }
+
+    @Test
+    @DisplayName("Processing queue에 빈자리 만큼 waiting queue에서 채워준다.")
+    void updateQueueTest() {
+        //given
+        List<User> all = userRepository.findAll();
+
+        // 작업을 마치고 나갈 10명 기록
+        List<QueueToken> tokens = new ArrayList<>();
+        for (int i = 0; i < 10; i++) {
+            Long userId = all.get(i).getId();
+            tokens.add(queueService.issueQueueToken(userId));
+        }
+
+        for (int i = 10; i < all.size() - 1; i++) {
+            Long userId = all.get(i).getId();
+            queueService.issueQueueToken(userId);
+        }
+
+        // 마지막에 접근한 1명을 기록
+        Long id = all.get(all.size() - 1).getId();
+        QueueToken queueToken = queueService.issueQueueToken(id);
+
+        //when
+        QueueResponse queueResponse1 = queueService.findQueueByToken(queueToken.token());
+
+        // 초반 10명을 processing queue에서 삭제
+        for (QueueToken token : tokens) {
+            queueService.deleteQueueToken(token.token());
+        }
+        queueScheduler.updateQueueStatus();
+
+        QueueResponse queueResponse2 = queueService.findQueueByToken(queueToken.token());
+
+        //then
+        assertThat(queueResponse1).isNotNull();
+        assertThat(queueResponse1.status()).isEqualTo(QueueStatus.WAITING);
+        assertThat(queueResponse1.remainingWaitingCount()).isEqualTo(100L);
+        assertThat(queueResponse1.estimatedWaitTime()).isEqualTo(0L);
+
+        assertThat(queueResponse2).isNotNull();
+        assertThat(queueResponse2.status()).isEqualTo(QueueStatus.WAITING);
+        assertThat(queueResponse2.remainingWaitingCount()).isEqualTo(90L);
+        assertThat(queueResponse2.estimatedWaitTime()).isEqualTo(0L);
     }
 
 }

--- a/src/test/java/com/example/book_your_seat/service/queue/QueueServiceTest.java
+++ b/src/test/java/com/example/book_your_seat/service/queue/QueueServiceTest.java
@@ -172,6 +172,7 @@ public class QueueServiceTest extends IntegerTestSupport {
         //given
         List<User> all = userRepository.findAll();
 
+        System.out.println("all = " + all.size());
         // 작업을 마치고 나갈 10명 기록
         List<QueueToken> tokens = new ArrayList<>();
         for (int i = 0; i < 200; i++) {
@@ -192,6 +193,7 @@ public class QueueServiceTest extends IntegerTestSupport {
         QueueResponse queueResponse1 = queueService.findQueueByToken(queueToken.token());
 
         // 초반 10명을 processing queue에서 삭제
+        System.out.println(tokens.size());
         for (QueueToken token : tokens) {
             queueService.deleteQueueToken(token.token());
         }

--- a/src/test/java/com/example/book_your_seat/service/queue/QueueServiceTest.java
+++ b/src/test/java/com/example/book_your_seat/service/queue/QueueServiceTest.java
@@ -1,0 +1,62 @@
+package com.example.book_your_seat.service.queue;
+
+import static org.assertj.core.api.Assertions.*;
+
+import com.example.book_your_seat.IntegerTestSupport;
+import com.example.book_your_seat.queue.controller.dto.QueueToken;
+import com.example.book_your_seat.queue.manager.QueueManager;
+import com.example.book_your_seat.queue.repository.RedisQueueRepository;
+import com.example.book_your_seat.queue.service.QueueService;
+import com.example.book_your_seat.user.domain.User;
+import com.example.book_your_seat.user.manager.UserManager;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.redis.core.RedisTemplate;
+
+public class QueueServiceTest extends IntegerTestSupport {
+
+    @Autowired
+    private QueueService queueService;
+
+    @Autowired
+    private QueueManager queueManager;
+
+    @Autowired
+    private UserManager userManager;
+
+    @Autowired
+    RedisQueueRepository redisQueueRepository;
+
+    @Autowired
+    private RedisTemplate<String, String> redisTemplate;
+
+    private User savedUser;
+
+    @BeforeEach
+    void beforeEach() {
+        savedUser = userManager.createUser(new User("nickname", "username", "email@email.com", "passwordpassowrd"));
+    }
+
+    @AfterEach
+    void afterEach() {
+        redisTemplate.getConnectionFactory().getConnection().flushAll();
+    }
+
+    @Test
+    @DisplayName("")
+    void issueTokenTest() {
+        // given
+        Long userId = savedUser.getId();
+        System.out.println(userId);
+
+        // when
+        QueueToken queueToken = queueService.issueQueueToken(userId);
+
+        // then
+        assertThat(queueToken).isNotNull();
+    }
+
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -5,3 +5,7 @@ spring:
     host: localhost
     port: 6379
     password:
+
+jwt:
+  secretKey: concert_jwt_secretconcert_jwt_secretconcert_jwt_secretconcert_jwt_secretconcert_jwt_secret
+  expiration: 1800000


### PR DESCRIPTION
<!--
  템플릿은 아직 PR 작성이 익숙하지 않으신 분들을 위해서 제공하는 가이드입니다!
  리뷰어 또는 이 PR을 보게 될 다른 사람들이 이 PR을 보는데 참고할 수 있는 내용이 있다면 포함해서 작성해주시면 됩니다.
-->

## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
![스크린샷 2024-10-02 오후 6 26 12](https://github.com/user-attachments/assets/056a2177-3ed1-4012-9eab-85c69c909576)

대기열을 구현했습니다.

### 대기열 진입
1. 사용자가 대기열에 접근하면 processing queue가 가득 차기 전까지 processing queue에 저장됩니다. (최대 1000명)
2. Processing queue가 가득 차면 waiting queue에 저장됩니다. 
3. 대기열 진입에 성공하면 토큰을 발급 받습니다. 

이미 대기열 안에 있으면 예외를 던집니다.

### 대기열 정보 조회
1. 발급 받은 토큰으로 대기열 상태를 조회합니다.
2. 현재 상태, 남은 대기열 인원, 예상 처리 시간을 반환합니다.

### 대기열 탈출
1. 발급 받은 토큰을 기반으로 대기열에서 탈출합니다.
2. processing queue, waiting queue 중 어디에 있었는지 파악하고, 해당 queue에서 삭제됩니다.

### 대기열 업데이트
1. 30초마다 대기열 상태를 업데이트 합니다.
2. processing queue의 빈자리 수를 확인합니다.
3. waiting queue에서 그만큼 가져옵니다.
4. waiting queue에서 삭제된 대기열을 processing queue로 넣어줍니다.

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->

## ✅ 피드백 반영사항  <!-- 지난 코드리뷰에서 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
