### PR TITLE
[FEAT] 테스트, 시연용 관리자 Role 획득 API 추가

### DIFF
--- a/src/main/java/com/example/book_your_seat/concert/controller/AdminConcertController.java
+++ b/src/main/java/com/example/book_your_seat/concert/controller/AdminConcertController.java
@@ -6,10 +6,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RequiredArgsConstructor
 @RequestMapping("/admin/api/v1/concerts")
@@ -24,6 +21,12 @@ public class AdminConcertController {
     ) {
         concertCommandService.add(request);
         return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+
+    @DeleteMapping("/{concertId}")
+    public ResponseEntity<Void> deleteById(@PathVariable final Long concertId) {
+        concertCommandService.delete(concertId);
+        return ResponseEntity.noContent().build();
     }
 
 }

--- a/src/main/java/com/example/book_your_seat/concert/controller/ConcertController.java
+++ b/src/main/java/com/example/book_your_seat/concert/controller/ConcertController.java
@@ -2,11 +2,13 @@ package com.example.book_your_seat.concert.controller;
 
 import com.example.book_your_seat.concert.controller.dto.ConcertResponse;
 import com.example.book_your_seat.concert.controller.dto.ResultRedisConcert;
-import com.example.book_your_seat.concert.service.ConcertCommandService;
 import com.example.book_your_seat.concert.service.ConcertQueryService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 
@@ -15,7 +17,6 @@ import java.util.List;
 @RestController
 public class ConcertController {
 
-    private final ConcertCommandService concertCommandService;
     private final ConcertQueryService concertQueryService;
 
     @GetMapping
@@ -28,12 +29,6 @@ public class ConcertController {
     public ResponseEntity<ConcertResponse> findById(@PathVariable final Long concertId) {
         ConcertResponse response = concertQueryService.findById(concertId);
         return ResponseEntity.ok(response);
-    }
-
-    @DeleteMapping("/{concertId}")
-    public ResponseEntity<Void> deleteById(@PathVariable final Long concertId) {
-        concertCommandService.delete(concertId);
-        return ResponseEntity.noContent().build();
     }
 
     @GetMapping("/redis/list")

--- a/src/main/java/com/example/book_your_seat/concert/service/ConcertQueryServiceImpl.java
+++ b/src/main/java/com/example/book_your_seat/concert/service/ConcertQueryServiceImpl.java
@@ -41,7 +41,6 @@ public class ConcertQueryServiceImpl implements ConcertQueryService {
                 .toList();
     }
 
-
     @Override
     @Cacheable(cacheNames = "concerts", key = "'allConcerts'")
     public ResultRedisConcert findUsedRedisAllConcertList() {

--- a/src/main/java/com/example/book_your_seat/config/SwaggerConfig.java
+++ b/src/main/java/com/example/book_your_seat/config/SwaggerConfig.java
@@ -1,16 +1,28 @@
 package com.example.book_your_seat.config;
 
+import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
 import org.springdoc.core.models.GroupedOpenApi;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+
+import java.util.Arrays;
 
 @Configuration
 public class SwaggerConfig {
     @Bean
     public OpenAPI openAPI() {
+        SecurityScheme securityScheme = new SecurityScheme()
+                .type(SecurityScheme.Type.HTTP).scheme("bearer").bearerFormat("JWT")
+                .in(SecurityScheme.In.HEADER).name("Authorization");
+        SecurityRequirement securityRequirement = new SecurityRequirement().addList("bearerAuth");
+
         return new OpenAPI()
+                .components(new Components().addSecuritySchemes("bearerAuth", securityScheme))
+                .security(Arrays.asList(securityRequirement))
                 .info(new Info()
                         .title("book-your-seat API")
                         .description("book-your-seat의 API 문서입니다.")

--- a/src/main/java/com/example/book_your_seat/user/controller/UserController.java
+++ b/src/main/java/com/example/book_your_seat/user/controller/UserController.java
@@ -87,4 +87,10 @@ public class UserController {
                 .body(userQueryService.getUserAddressList(user));
     }
 
+    @PatchMapping("/role")
+    public ResponseEntity<TokenResponse> changeRoleToAdminForTest(@LoginUser User user) {
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(userFacade.changeRoleToAdminForTest(user.getId()));
+    }
 }

--- a/src/main/java/com/example/book_your_seat/user/domain/User.java
+++ b/src/main/java/com/example/book_your_seat/user/domain/User.java
@@ -63,6 +63,10 @@ public class User extends BaseEntity {
         this.userRole = UserRole.USER;
     }
 
+    public void changeRoleToAdmin() {
+        this.userRole = UserRole.ADMIN;
+    }
+
     public void setAddress(Address address) {
         this.addressList.add(address);
     }

--- a/src/main/java/com/example/book_your_seat/user/service/command/UserCommandService.java
+++ b/src/main/java/com/example/book_your_seat/user/service/command/UserCommandService.java
@@ -1,11 +1,17 @@
 package com.example.book_your_seat.user.service.command;
 
-import com.example.book_your_seat.user.controller.dto.*;
+import com.example.book_your_seat.user.controller.dto.JoinRequest;
+import com.example.book_your_seat.user.controller.dto.LoginRequest;
+import com.example.book_your_seat.user.controller.dto.TokenResponse;
+import com.example.book_your_seat.user.controller.dto.UserResponse;
+import com.example.book_your_seat.user.domain.User;
 
 public interface UserCommandService {
 
     UserResponse join(JoinRequest joinRequest);
 
     TokenResponse login(LoginRequest loginRequest);
+
+    TokenResponse changeRoleToAdmin(User user);
 
 }

--- a/src/main/java/com/example/book_your_seat/user/service/command/UserCommandServiceImpl.java
+++ b/src/main/java/com/example/book_your_seat/user/service/command/UserCommandServiceImpl.java
@@ -57,4 +57,12 @@ public class UserCommandServiceImpl implements UserCommandService {
             throw new IllegalArgumentException(INVALID_LOGIN_REQUEST);
         }
     }
+
+    @Override
+    public TokenResponse changeRoleToAdmin(User user) {
+        user.changeRoleToAdmin();
+        userRepository.save(user);
+        return new TokenResponse(securityJwtUtil.createJwt(user));
+    }
+
 }

--- a/src/main/java/com/example/book_your_seat/user/service/facade/UserFacade.java
+++ b/src/main/java/com/example/book_your_seat/user/service/facade/UserFacade.java
@@ -1,6 +1,7 @@
 package com.example.book_your_seat.user.service.facade;
 
 import com.example.book_your_seat.user.controller.dto.*;
+import com.example.book_your_seat.user.domain.User;
 
 import java.util.concurrent.CompletableFuture;
 
@@ -16,5 +17,7 @@ public interface UserFacade {
     Boolean sendCertMail(String mail);
 
     Boolean checkCertCode(String mail, String certCode);
+
+    TokenResponse changeRoleToAdminForTest(Long userId);
 
 }

--- a/src/main/java/com/example/book_your_seat/user/service/facade/UserFacadeImpl.java
+++ b/src/main/java/com/example/book_your_seat/user/service/facade/UserFacadeImpl.java
@@ -1,9 +1,6 @@
 package com.example.book_your_seat.user.service.facade;
 
-import com.example.book_your_seat.user.controller.dto.AddAddressRequest;
-import com.example.book_your_seat.user.controller.dto.AddressIdResponse;
-import com.example.book_your_seat.user.controller.dto.JoinRequest;
-import com.example.book_your_seat.user.controller.dto.UserResponse;
+import com.example.book_your_seat.user.controller.dto.*;
 import com.example.book_your_seat.user.domain.Address;
 import com.example.book_your_seat.user.domain.User;
 import com.example.book_your_seat.user.mail.service.MailService;
@@ -60,5 +57,11 @@ public class UserFacadeImpl implements UserFacade {
     @Override
     public Boolean checkCertCode(String email, String certCode) {
         return mailService.checkCertCode(email, certCode);
+    }
+
+    @Override
+    public TokenResponse changeRoleToAdminForTest(Long userId) {
+        User user = userQueryService.getUserByUserId(userId);
+        return userCommandService.changeRoleToAdmin(user);
     }
 }


### PR DESCRIPTION
## 📌 과제 설명 
테스트, 시연용 관리자 Role 획득 API를 추가하였습니다.
## 👩‍💻 요구 사항과 구현 내용 
로직대로 회원가입, 로그인 후에  patch `/api/v1/users/role` 로 요청을 보내면, 관리자 권한으로 바뀌어 새로운 토큰이 발급됩니다. 해당 토큰으로 새롭게 인증 후에 관리자 API 이용하시면 됩니다!

### Swagger Authorization 추가 방법
<img width="942" alt="스크린샷 2024-10-10 오후 12 26 14" src="https://github.com/user-attachments/assets/eca2b933-cfee-4f96-8f74-0147a7bc1041">
* 여기서 반환되는 토큰을

<img width="957" alt="스크린샷 2024-10-10 오후 12 26 34" src="https://github.com/user-attachments/assets/6cab3f97-7b1a-4c1a-ad83-a0b7d42b0028">

* 여기에 복사붙여넣기 하고 Authorize 클릭하면 됩니다!