### PR TITLE
[FEAT] 이미지 저장 로직 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -70,10 +70,14 @@ dependencies {
 	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 	
 	//슬랙 api 추가
-
 	implementation("com.slack.api:bolt:1.18.0")
 	implementation("com.slack.api:bolt-servlet:1.18.0")
 	implementation("com.slack.api:bolt-jetty:1.18.0")
+
+	//s3
+	implementation 'io.awspring.cloud:spring-cloud-starter-aws:2.4.4'
+	implementation 'com.amazonaws:aws-java-sdk-s3:1.12.765'
+	implementation 'javax.xml.bind:jaxb-api:2.4.0-b180830.0359'
 
 }
 

--- a/src/main/java/com/example/book_your_seat/config/S3Config.java
+++ b/src/main/java/com/example/book_your_seat/config/S3Config.java
@@ -1,0 +1,33 @@
+package com.example.book_your_seat.config;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class S3Config {
+
+    @Value("${cloud.aws.credentials.access-key}")
+    private String accessKey;
+
+    @Value("${cloud.aws.credentials.secret-key}")
+    private String secretKey;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public AmazonS3Client amazonS3Client() {
+        BasicAWSCredentials credentials = new BasicAWSCredentials(accessKey, secretKey);
+        return (AmazonS3Client) AmazonS3ClientBuilder
+                .standard()
+                .withCredentials(new AWSStaticCredentialsProvider(credentials))
+                .withRegion(region)
+                .build();
+    }
+
+}

--- a/src/main/java/com/example/book_your_seat/image/domain/Image.java
+++ b/src/main/java/com/example/book_your_seat/image/domain/Image.java
@@ -1,0 +1,28 @@
+package com.example.book_your_seat.image.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Image {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "image_id")
+    private Long id;
+
+    private Long concertId;
+    private String imageUrl;
+
+    public Image(Long concertId, String imageUrl) {
+        this.concertId = concertId;
+        this.imageUrl = imageUrl;
+    }
+}

--- a/src/main/java/com/example/book_your_seat/image/repository/ImageRepository.java
+++ b/src/main/java/com/example/book_your_seat/image/repository/ImageRepository.java
@@ -1,0 +1,4 @@
+package com.example.book_your_seat.image.repository;
+
+public interface ImageRepository {
+}

--- a/src/main/java/com/example/book_your_seat/s3/FileExtension.java
+++ b/src/main/java/com/example/book_your_seat/s3/FileExtension.java
@@ -1,0 +1,22 @@
+package com.example.book_your_seat.s3;
+
+public enum FileExtension {
+    JPG("jpg"),
+    JPEG("jpeg"),
+    PNG("png");
+
+    private final String extension;
+
+    FileExtension(String extension) {
+        this.extension = extension;
+    }
+
+    public static boolean isValidExtension(String fileName) {
+        for (FileExtension ext : FileExtension.values()) {
+            if (fileName.toLowerCase().endsWith("." + ext.extension.toLowerCase())) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/src/main/java/com/example/book_your_seat/s3/S3ImageController.java
+++ b/src/main/java/com/example/book_your_seat/s3/S3ImageController.java
@@ -1,0 +1,34 @@
+package com.example.book_your_seat.s3;
+
+import com.example.book_your_seat.s3.dto.UploadRequest;
+import com.example.book_your_seat.s3.dto.UploadResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/images")
+@RequiredArgsConstructor
+public class S3ImageController {
+
+    private final S3ImageService s3ImageService;
+
+    @PostMapping
+    public ResponseEntity<UploadResponse> uploadFile(@ModelAttribute UploadRequest uploadRequest) throws IOException {
+        return ResponseEntity.ok(
+                s3ImageService.upload(uploadRequest.files())
+        );
+    }
+
+    @DeleteMapping
+    public ResponseEntity<Void> deleteImage(@RequestParam("fileUrl") String fileUrl) {
+        s3ImageService.delete(fileUrl);
+        return ResponseEntity.ok(null);
+    }
+}

--- a/src/main/java/com/example/book_your_seat/s3/S3ImageService.java
+++ b/src/main/java/com/example/book_your_seat/s3/S3ImageService.java
@@ -1,0 +1,67 @@
+package com.example.book_your_seat.s3;
+
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.DeleteObjectRequest;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.amazonaws.util.IOUtils;
+import com.example.book_your_seat.s3.dto.UploadResponse;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+@Service
+@RequiredArgsConstructor
+public class S3ImageService {
+
+    private final AmazonS3Client amazonS3Client;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    public UploadResponse upload(MultipartFile file) throws IOException {
+        String fileName = file.getOriginalFilename();
+        if (fileName == null || fileName.isEmpty()) {
+            throw new IllegalArgumentException("올바른 파일 이름 형식이 아닙니다.");
+        }
+
+        validateExtension(fileName);
+
+        String createFileName = createFileName(fileName);
+        ObjectMetadata objMeta = new ObjectMetadata();
+        byte[] bytes = IOUtils.toByteArray(file.getInputStream());
+        objMeta.setContentLength(bytes.length);
+        ByteArrayInputStream byteArrayIs = new ByteArrayInputStream(bytes);
+
+        amazonS3Client.putObject(
+                new PutObjectRequest(bucket, createFileName, byteArrayIs, objMeta)
+                        .withCannedAcl(CannedAccessControlList.PublicRead)
+        );
+        return new UploadResponse(
+                amazonS3Client.getUrl(bucket, createFileName).toString()
+        );
+    }
+
+    public void delete(String fileUrl) {
+        String objectKey = fileUrl.split(bucket + ".s3." + region + ".amazonaws.com/")[1];
+        amazonS3Client.deleteObject(new DeleteObjectRequest(bucket, objectKey));
+    }
+
+    private String createFileName(String fileName) {
+        return "image/" + UUID.randomUUID() + fileName;
+    }
+
+    private void validateExtension(String fileName) {
+        if (!FileExtension.isValidExtension(fileName)) {
+            throw new IllegalArgumentException("올바른 파일 확장자 형식이 아닙니다. (jpg, jpeg, png)");
+        }
+    }
+}

--- a/src/main/java/com/example/book_your_seat/s3/dto/UploadRequest.java
+++ b/src/main/java/com/example/book_your_seat/s3/dto/UploadRequest.java
@@ -1,0 +1,8 @@
+package com.example.book_your_seat.s3.dto;
+
+import org.springframework.web.multipart.MultipartFile;
+
+public record UploadRequest(
+        MultipartFile files
+) {
+}

--- a/src/main/java/com/example/book_your_seat/s3/dto/UploadResponse.java
+++ b/src/main/java/com/example/book_your_seat/s3/dto/UploadResponse.java
@@ -1,0 +1,6 @@
+package com.example.book_your_seat.s3.dto;
+
+public record UploadResponse(
+        String fileUrl
+) {
+}


### PR DESCRIPTION
<!--
  템플릿은 아직 PR 작성이 익숙하지 않으신 분들을 위해서 제공하는 가이드입니다!
  리뷰어 또는 이 PR을 보게 될 다른 사람들이 이 PR을 보는데 참고할 수 있는 내용이 있다면 포함해서 작성해주시면 됩니다.
-->

## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
이미지를 s3에 저장하고 반환받은 ImageUrl을 엔티티로 저장해서 관리합니다.
지금 콘서트 쪽을 수정학 있는 부분이 있는 것 같아서 우선 저장 기틀만 구현했고, 
나중에 콘서트 쪽이 정리되면 추가 작업 하겠습니다!

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->

## ✅ 피드백 반영사항  <!-- 지난 코드리뷰에서 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
